### PR TITLE
Release 2.4.1 — version bump + changelog for the first dogfood day

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "multica-ops",
   "description": "Mops (Executive Advisor) for Multica: builds and runs an autonomous company of AI agents — interview, bootstrap, conveyor, console.",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "author": {
     "name": "Jamil Lazarev",
     "url": "https://github.com/jamillazarev"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 2.4.1
+
+**first dogfood day: the traps the skill hit running itself**
+
+- **Interview item 19 rewritten — language is three layers**: the CLI mirrors the speaker;
+  the working language of shared threads stays steady (a resident 1:1 may mirror, opt-in);
+  the artifact default is **derived** — public/international → EN, local → the chat
+  language — and stated with its reasoning. Per-member language preferences → LATER.
+- **BOOTSTRAP §8 — three CLI traps from live runs**: list commands return a bare array *or*
+  a wrapper object, and write commands print a human line *before* the JSON even with
+  `--output json` — parse defensively and check exit codes (`scripts/issues.py` `_clean` is
+  the pattern) · `workspace switch` can fail silently, so **batch creation always passes
+  `--workspace-id` explicitly**.
+- **Interview item 8: tier is model × thinking-level**, asked together, in outcomes.
+- **STACKS: graphify leads the Codebase-orientation generated-index slot** (MIT/Apache-2.0,
+  Tree-sitter AST parsing, code parsed 100% locally; upstream claims attributed to its
+  README, not our measurements) — DSP stays as the alternative.
+
 ## 2.4.0
 
 **the platform-audit release: the skill tells the truth about Multica — and can run itself**

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: multica-ops
-version: 2.4.0
+version: 2.4.1
 description: Use when the user wants to build, bootstrap, join, or operate an autonomous team of AI agents on Multica — you act as their Mops (Executive Advisor); interview them progressively (defaults everywhere, small tasks stay small), create everything via the CLI (workspace-as-company, conductor/PM, agents, squads, skills, integrations), optionally stand up a resident Mops inside the workspace, then stay their console for status, recovery, features, and reshaping the team.
 ---
 


### PR DESCRIPTION
Since the v2.4.0 tag, three content PRs (#1 #2 #3) landed on main with the skill still
reporting \`version: 2.4.0\` — anyone installing got changed content under the old version.
This PR closes the drift:

- \`SKILL.md\` frontmatter → **2.4.1**
- \`CHANGELOG.md\` → new **2.4.1** section batching everything since the tag: interview
  item 19 (language, three layers), BOOTSTRAP §8 CLI traps (JSON shapes · prose-before-JSON ·
  wrong-workspace), item 8 (model × thinking), STACKS graphify row.

Process note (also in FIELD-NOTES): this was a conductor-side miss — content PRs merged with
no release step. Fix-candidate: PR checklist gains "user-facing change ⇒ version + changelog
line, or an explicit release PR follows the batch".

After merge I'll tag \`v2.4.1\` on the merge commit. Human merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)