### PR TITLE
Hotfix 2.5.1 — the primary source moved; re-verification did its job

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "multica-ops",
   "description": "Mops (Executive Advisor) for Multica: builds and runs an autonomous company of AI agents — interview, bootstrap, conveyor, console.",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "license": "Apache-2.0",
   "author": {
     "name": "Jamil Lazarev",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 2.5.1
+
+**Stanford citations re-verified — the primary source moved, and re-verification caught it**
+
+- **The paper was retitled.** arXiv:2411.10109 is now *LLM Agents Grounded in Self-Reports Enable
+  General-Purpose Simulation of Individuals* (v3, 2026-06-28); v1 was *Generative Agent Simulations
+  of 1,000 People*, which the May-2025 Stanford HAI brief still matches. Every MODULES citation now
+  names the current title and flags the v1/brief lineage.
+- **Numbers corrected to the current abstract** (re-verified 2026-07-26): interview-grounded **83%**
+  / survey **82%** / combined **86%** / demographics-only **74%** of two-week test-retest — replacing
+  the brief-era "~85%, 14–15 p.p." The interview-vs-demographics gap is **~9 p.p.**, and **combined
+  self-reports beat interview-only** (86 > 83).
+- **Grounding = self-reports, not interviews alone.** The transcript chain stays the spine; surveys
+  are now named a legitimate supplement. The interview remains the strongest single source.
+- **Bias claim cites honestly.** The current abstract's own finding — self-report agents **reduce
+  accuracy disparities** across racial/ideological groups vs demographics-only — now carries the
+  never-from-demographics rule; the stronger "amplify stereotype bias" phrasing is attributed to the
+  Stanford HAI brief (brief-era, v3 status unverified). `templates/PERSONA-template.md` aligned.
+- No behaviour change — citations and provenance only.
+
 ## 2.5.0
 
 **Persona Theatre v2 — evidence-grounded audiences, honest about what a simulation can't tell you**

--- a/MODULES.md
+++ b/MODULES.md
@@ -146,17 +146,24 @@ verdicts honest about what a simulation can and cannot tell you. On via `/mops m
 on`; personas live as documents first and become agents only for a round.
 
 **Grounded in the research — which says the grounding *is* the product** (owner-supplied
-sources, read 2026-07-26 — Stanford HAI brief *Simulating Human Behavior with AI Agents*, Park
-et al. May 2025, the 1,000-people generative-agents study; Mahajan's synthetic-users taxonomy;
-carried as facts recorded on that date):
+sources; the primary paper re-verified 2026-07-26 against the current arXiv version — Park et
+al., *LLM Agents Grounded in Self-Reports Enable General-Purpose Simulation of Individuals*
+(arXiv:2411.10109; v1 was *Generative Agent Simulations of 1,000 People*, and the May-2025
+Stanford HAI brief *Simulating Human Behavior with AI Agents* matches the v1 framing);
+Mahajan's synthetic-users taxonomy; carried as facts recorded on that date):
 
-- an LLM given a **2-hour in-depth interview** replicated individuals' survey answers at **~85%
-  normalized accuracy** (ceiling = the person's own two-week test-retest), **14–15 p.p. above
-  demographic- or persona-based agents on the same model** (checked 2026-07-26) — so fidelity
-  comes from **the interview transcript**, not a bio;
-- **demographic personas amplify stereotype bias; interview-grounded agents narrowed
-  demographic-parity gaps** across tasks (checked 2026-07-26) — so a bias profile is
-  **evidence-grounded or it does not ship**;
+- **self-reports ground the fidelity**: agents built from a person's own self-reports replicated
+  their survey answers at **83% (interview-grounded) / 82% (survey-grounded) / 86% (both)** of
+  the person's own two-week test-retest ceiling, vs **74% for demographics-only** (re-verified
+  2026-07-26 against the current arXiv version) — the **interview is the strongest single
+  source** and surveys **add** (86% combined), so the **transcript chain stays the spine and
+  surveys are a legitimate supplement**, not a bio; the interview-vs-demographics gap is **~9
+  p.p.** (83 vs 74) at the abstract level, narrower than the brief-era 14–15 p.p.;
+- **self-report agents reduce accuracy disparities across racial and ideological groups relative
+  to demographics-only** (current abstract, re-verified 2026-07-26); the stronger **"demographic
+  personas amplify stereotype bias"** phrasing is the **May-2025 Stanford HAI brief's** (brief-era
+  finding, its v3 status unverified) — either way, a bias profile is **evidence-grounded or it
+  does not ship**;
 - **synthetics cluster toward neutral** — they catch direction, miss extremes and magnitudes
   (Mahajan, checked 2026-07-26) — so a synthetic verdict states **direction, never magnitude**.
 
@@ -191,8 +198,9 @@ source**:
   (that pooled distillation is its grounding artifact) — a segment, not one person;
 - a **proto-persona's** come from **published cognitive-science literature, source named** (a
   documented effect, not a guess);
-- **never assigned from demographics** — that is the tier Stanford measured 14–15 p.p. worse and
-  bias-amplifying (checked 2026-07-26).
+- **never assigned from demographics** — that is the tier the study measured **~9 p.p. worse**
+  (83 vs 74) and with **larger accuracy disparities** across racial/ideological groups
+  (re-verified 2026-07-26; the brief-era "bias-amplifying" framing put the gap at 14–15 p.p.).
 
 The profile is **core to the audience side, not a lookup table**: a persona with loss aversion
 is a **dark-pattern detector** — a screen that "works" only because it presses her fear is a

--- a/MODULES.md
+++ b/MODULES.md
@@ -158,14 +158,17 @@ Mahajan's synthetic-users taxonomy; carried as facts recorded on that date):
   2026-07-26 against the current arXiv version) — the **interview is the strongest single
   source** and surveys **add** (86% combined), so the **transcript chain stays the spine and
   surveys are a legitimate supplement**, not a bio; the interview-vs-demographics gap is **~9
-  p.p.** (83 vs 74) at the abstract level, narrower than the brief-era 14–15 p.p.;
+  p.p.** (83 vs 74) at the abstract level, narrower than the brief's now-superseded estimate;
 - **self-report agents reduce accuracy disparities across racial and ideological groups relative
   to demographics-only** (current abstract, re-verified 2026-07-26); the stronger **"demographic
   personas amplify stereotype bias"** phrasing is the **May-2025 Stanford HAI brief's** (brief-era
   finding, its v3 status unverified) — either way, a bias profile is **evidence-grounded or it
   does not ship**;
 - **synthetics cluster toward neutral** — they catch direction, miss extremes and magnitudes
-  (Mahajan, checked 2026-07-26) — so a synthetic verdict states **direction, never magnitude**.
+  (Mahajan, checked 2026-07-26; strongest current evidence: LLMs track experimental
+  **directions** at **r≈0.85** while systematically **overestimating effect sizes** — Ashokkumar
+  et al., *Nature* (advance online publication, 2026-07-08), doi:10.1038/s41586-026-10742-x,
+  checked 2026-07-26) — so a synthetic verdict states **direction, never magnitude**.
 
 ### Staging — proto-persona → validated persona
 Two stages, always marked, never blurred:
@@ -200,7 +203,10 @@ source**:
   documented effect, not a guess);
 - **never assigned from demographics** — that is the tier the study measured **~9 p.p. worse**
   (83 vs 74) and with **larger accuracy disparities** across racial/ideological groups
-  (re-verified 2026-07-26; the brief-era "bias-amplifying" framing put the gap at 14–15 p.p.).
+  (re-verified 2026-07-26; the brief-era "bias-amplifying" framing overstated the gap —
+  superseded by the current version). And **not from a bio paragraph either**: persona-paragraph
+  agents score **0.71 in the current version — below even the demographics baseline** (0.74), so a
+  written "portrait" is the **worst grounding tier**, not a shortcut.
 
 The profile is **core to the audience side, not a lookup table**: a persona with loss aversion
 is a **dark-pattern detector** — a screen that "works" only because it presses her fear is a

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: multica-ops
-version: 2.5.0
+version: 2.5.1
 description: Use when the user wants to build, bootstrap, join, or operate an autonomous team of AI agents on Multica — you act as their Mops (Executive Advisor); interview them progressively (defaults everywhere, small tasks stay small), create everything via the CLI (workspace-as-company, conductor/PM, agents, squads, skills, integrations), optionally stand up a resident Mops inside the workspace, then stay their console for status, recovery, features, and reshaping the team.
 ---
 

--- a/templates/PERSONA-template.md
+++ b/templates/PERSONA-template.md
@@ -42,9 +42,9 @@ hosted STT only with consent recorded there.
 
 **Rules:** a twin's biases come from **its own transcript**; a **validated non-twin's** from the
 **pooled segment transcripts / QDA** (its grounding artifact); a proto-persona's from **named
-cognitive-science literature**; **never assigned from demographics** (interview-grounding narrowed
-demographic-parity gaps; demographic personas amplify stereotype bias — Stanford, checked
-2026-07-26).
+cognitive-science literature**; **never assigned from demographics** (self-report grounding
+reduces accuracy disparities across racial/ideological groups vs demographics-only — Park et al.,
+re-verified 2026-07-26; the "amplify stereotype bias" framing is the Stanford HAI brief's).
 
 ## Accuracy score (twins only)
 


### PR DESCRIPTION
arXiv:2411.10109 was retitled (v3: "LLM Agents Grounded in Self-Reports Enable General-Purpose Simulation of Individuals") and its numbers revised — the skill cited the May-2025 HAI brief. Updated: 83/82/86/74 (interview/survey/combined/demographics of test-retest), ~9 p.p. gap; disparity-reduction cited from the CURRENT abstract, the stronger "amplify" phrasing attributed to the brief. Two verified strengtheners: persona-paragraph agents score 0.71 — below even demographics (a written "portrait" is the worst grounding tier), and the direction-not-magnitude rule gains its strongest citation (Ashokkumar et al., Nature AOP 2026-07-08, r≈0.85 on directions with systematic effect-size overestimation — cited by DOI after the reviewer caught a hallucinated volume:pages locator across three bibliographic databases).

Review record: reviewer independently fetched the arXiv page AND the v3 PDF (0.71/0.74 confirmed in the results text), REQUEST CHANGES twice (brief-era digits inline; the invented pinpoint), both fixed in the reviewer's own dictated form. The check-date system worked exactly as designed: dated facts, re-verified, updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)