### PR TITLE
2.5.4 — The telemetry core: local events, MD dashboards, dark PostHog slot

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "multica-ops",
   "description": "Mops (Executive Advisor) for Multica: builds and runs an autonomous company of AI agents — interview, bootstrap, conveyor, console.",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "license": "Apache-2.0",
   "author": {
     "name": "Jamil Lazarev",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,8 +148,13 @@ A version bump is not just a changelog entry. Before you tag:
    that no longer matches reality passes silently, which is worse than no guard.
 4. **Every new capability has a door, or a stated reason it doesn't** — see *When a flow
    deserves a command*. Reachability is guarded; the decision to add a command is not.
-5. **`bash scripts/preflight.sh`, `python3 scripts/verify.py --live`, and `python3 scripts/fetch-source.py --verify` green** (warnings named) — the last walks `sources/SOURCES.md` so the register's live URLs are re-checked each release alongside the skill's own sources.
-6. **Changelog** leads with the capability or the consequence, not the archaeology of how a
+5. **Every new capability carries its events** — instrumentation ships *with* the feature,
+   not after. A feature change carries its `telemetry/TRACKING-PLAN.md` diff (or the spec
+   states plainly *no events needed* as a stated decision — a feature without its events is
+   a dark feature), and the tracking-plan / dashboard spec is updated where the new signal
+   warrants. This is guarded by nobody; it is a discipline.
+6. **`bash scripts/preflight.sh`, `python3 scripts/verify.py --live`, and `python3 scripts/fetch-source.py --verify` green** (warnings named) — the last walks `sources/SOURCES.md` so the register's live URLs are re-checked each release alongside the skill's own sources.
+7. **Changelog** leads with the capability or the consequence, not the archaeology of how a
    defect was found (that goes in the commit message).
 
 **Then the cut itself, in order — the last two steps were live misses caught on 2.4.1:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@
 - **The DoD rule.** A release now carries its tracking-plan diff or states "no events
   needed" as a decision (AGENTS.md release ritual): a feature without its events is a dark
   feature.
+- **Eval scenario 16** guards the one judgment-dependent piece: the Mops-side logging rules
+  in PLAYBOOKS (coarse-class values only, invisible to the owner, never blocking). The
+  scripts' self-logging needs no scenario — it is deterministic code, tested in review.
 
 ## 2.5.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## 2.5.4
+
+**The telemetry core — fully local, events never deferred, viewing layer as generated markdown**
+
+- **Tracking plan.** New `telemetry/TRACKING-PLAN.md` — the event taxonomy defined once,
+  sink-agnostic: commands, companion loads (the 2.6 family-split evidence), tool invocations
+  (feeds the future toolbox GC), conveyor stages, consult sessions, economy nudges, source
+  challenges. Every event is tier-1 LOCAL: nothing leaves the machine in this release.
+- **The dispatcher.** New `scripts/telemetry.py` — `log <event>` appends one JSON line to a
+  local ledger (`$MOPS_TELEMETRY_DIR` → `company/telemetry/` → `~/.multica-ops/telemetry/`);
+  telemetry never breaks real work (any failure is a warning, exit 0); an off switch is
+  honored. Sinks by config: the JSONL ledger is always on; **PostHog is a designed, dark
+  slot** — recognized in `telemetry/sinks.json`, shipped with the wire cut (no HTTP call in
+  the code), enabled only by the owner's future call at Atlas.
+- **Dashboards as generated markdown.** New `scripts/telemetry-report.py` — aggregates the
+  ledger into MD dashboards next to it (commands, companion load frequency, tool usage with
+  last-used, conveyor health, consult funnel); versioned where the ledger lives, so a
+  release can show its metric deltas as a diff.
+- **Scripts self-log.** The existing ops scripts (`health`, `resume`, `verify`,
+  `import-issues`, `issues`, `fetch-source`, `preflight`) emit their own `tool_invoked`
+  events — the guaranteed channel; Mops-side logging rules land in PLAYBOOKS as the
+  best-effort channel, and the difference is stated plainly.
+- **`TELEMETRY.md`.** What is collected, where the ledger lives, the off switch, and the
+  dark-slot statement — the whole privacy story on one page.
+- **The DoD rule.** A release now carries its tracking-plan diff or states "no events
+  needed" as a decision (AGENTS.md release ritual): a feature without its events is a dark
+  feature.
+
 ## 2.5.3
 
 **The sources register v1 — every slow-rotting claim carries its evidence, and "where did you get this?" is answerable**

--- a/PLAYBOOKS.md
+++ b/PLAYBOOKS.md
@@ -41,6 +41,7 @@ control characters that break `json.loads` — sanitize with
 - [Economics — what the company actually costs](#economics-what-the-company-actually-costs)
 - [Tool knowledge — where it goes (and where it must not)](#tool-knowledge-where-it-goes-and-where-it-must-not)
 - [Launch checklist — what "done" requires, per medium](#launch-checklist-what-done-requires-per-medium)
+- [Telemetry — logging events by rule](#telemetry-logging-events-by-rule)
 
 ## You are the console — map the user's phrases to actions
 
@@ -728,3 +729,37 @@ check the platform's current docs rather than recalling them).
 - **Physical batch**: labels · barcodes · compliance marks · shipping docs.
 
 Anything the team can't do yet → find-skills or the role-builder, before ship day.
+
+## Telemetry — logging events by rule
+
+The skill measures itself so decisions rest on usage, not memory. Two kinds of events:
+**script-driven** ones fire on their own (each ops helper self-logs its `tool_invoked`),
+and **model-side** ones only Mops can see — those Mops logs by rule, below. The taxonomy
+is fixed once in `telemetry/TRACKING-PLAN.md`; what is collected and how to switch it off
+is `TELEMETRY.md`. Everything stays on the local machine in this release.
+
+**Set the session once**, at the start of a chat, so a session's events group without ever
+recording who or where: `export MOPS_SESSION_ID=$(python3 -c 'import uuid;print(uuid.uuid4().hex[:16])')`.
+
+**WHEN Mops logs — the exact one-liner** (run from the skill repo root):
+
+| WHEN | Run |
+|---|---|
+| a command starts | `python3 scripts/telemetry.py log command_invoked --prop command=<name> --prop entrance=<shape\|explicit> --prop mode=<mode>` |
+| a companion file loads | `python3 scripts/telemetry.py log companion_loaded --prop file=<FILE.md> --prop trigger=<command\|question\|stage>` |
+| work crosses a conveyor stage | `python3 scripts/telemetry.py log conveyor_advanced --prop release=<x.y.z> --prop stage=<executor\|review\|eval\|tail> --prop round=<n> --prop verdict=<pass\|revise\|block>` |
+| a consult session ends | `python3 scripts/telemetry.py log consult_ended --prop addressee_class=<mops\|agent\|expert\|theatre> --prop converted=<true\|false> --prop ephemeral_validation=<true\|false>` |
+
+Two more fire on the occasion they name: `economy_nudged` (`--prop kind=<compact\|fresh_chat\|tier_down> --prop heeded=<true\|false\|unknown>`) when Mops suggests an
+economy move, and `source_challenged` (`--prop answered_from=<register\|live_fetch\|judgement>`) when Mops answers "where did you get this?".
+
+**The never-block rule.** Telemetry is best-effort and must never delay or fail real work.
+The dispatcher already swallows every error (a dropped event is cheaper than a stalled
+command); never wait on it, never surface a telemetry failure to the user, never reorder
+the user's request behind it. **Never log anything user-identifiable** — no names, paths,
+project ids, URLs or free text; classify instead (`args_class`, `addressee_class`).
+
+**The honest limitation.** Instruction-driven logging (this table) is best-effort — Mops
+may forget, and that is expected. Script-driven logging is guaranteed. That is exactly why
+**anything a script can measure is logged in the script**, not here: the reliable path
+carries the load, and these rules cover only what no script can see.

--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ The whole company, end to end — and the loop closes, it doesn't stop at merge:
 | [PLAYBOOKS.md](PLAYBOOKS.md) | daily operations, copy-paste ready |
 | [REFERENCE.md](REFERENCE.md) | object model, anti-patterns, **CLI surface (§10)**, **frameworks (§11)** |
 | [WORKFLOW.md](WORKFLOW.md) | Mermaid diagrams of the whole process |
+| [TELEMETRY.md](TELEMETRY.md) | the local telemetry core — what is collected, where the ledger lives, the off switch, the dark PostHog slot |
 | [CHANGELOG.md](CHANGELOG.md) | versioned history — the migration map for `/mops upgrade` |
 | [BUDGET template](templates/BUDGET-template.md) | envelope · currency · credits with expiries · prices on record |
 | [evals/](evals/) | stratified scenarios — from a job too small to deserve a company to an import carrying a hidden instruction |

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: multica-ops
-version: 2.5.3
+version: 2.5.4
 description: Use when the user wants to build, bootstrap, join, or operate an autonomous team of AI agents on Multica — you act as their Mops (Executive Advisor); interview them progressively (defaults everywhere, small tasks stay small), create everything via the CLI (workspace-as-company, conductor/PM, agents, squads, skills, integrations), optionally stand up a resident Mops inside the workspace, then stay their console for status, recovery, features, and reshaping the team.
 ---
 

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -1,0 +1,54 @@
+# Telemetry — local, and staying local
+
+The skill measures itself so decisions rest on usage, not memory: which commands run,
+which companion files load, which tools go cold, how the conveyor and consults flow. This
+release is the **telemetry core, fully local** — everything below stays on the machine.
+
+## What is collected
+
+Seven events, defined once in `telemetry/TRACKING-PLAN.md` (the sink-agnostic taxonomy):
+`command_invoked`, `companion_loaded`, `tool_invoked`, `conveyor_advanced`,
+`consult_ended`, `economy_nudged`, `source_challenged`. Every event carries only `ts`,
+`skill_version` and a random per-session `session_id`. **Nothing user-identifiable is
+recorded** — no hostname, username, path, project id, URL or free text. Tool args are
+logged as a coarse class (`live`, `apply`, `revive`, …), never the raw values.
+
+## Where it lives
+
+A local append-only ledger, `events.jsonl`. The dispatcher (`scripts/telemetry.py`)
+resolves its directory in this order:
+
+1. `$MOPS_TELEMETRY_DIR` — an explicit directory (and the off switch, below).
+2. `company/telemetry/` — when a `company/` dir exists (gitignored by convention, so
+   tier-1 data is never committed to this public repo).
+3. `~/.multica-ops/telemetry/` — the fallback.
+
+The dashboard is generated **next to the ledger** by `scripts/telemetry-report.py`
+(`DASHBOARD.md`), never into the repo's tracked files.
+
+## What never leaves the machine
+
+**Everything, in this release.** Each event is TIER-1 LOCAL and is never transmitted.
+The dispatcher ships no HTTP call.
+
+## The dark PostHog slot
+
+`telemetry/sinks.json` recognizes a `posthog` sink, but the **wire is cut**: it is
+disabled, its key is null, and even if configured the code forwards nothing — it prints a
+notice and makes no network call. The slot exists so turning it on later is config, not a
+code change; whether to ever enable it is the owner's call. **No secrets are committed** —
+a key, if the day comes, is supplied via `$MOPS_POSTHOG_API_KEY`.
+
+## How to switch it off
+
+Set `MOPS_TELEMETRY_DIR=off` (also accepts `0`, `false`, `none`, `disabled`). The
+dispatcher then does nothing and exits cleanly. Telemetry is also **fail-open by design**:
+any error at all degrades to a one-line stderr warning and a clean exit — a dropped event
+never breaks the command that emitted it.
+
+## How events are emitted (honest)
+
+This is a skill, not a daemon. Ops scripts self-log their own `tool_invoked` on run
+(guaranteed); Mops logs the model-side events by rule (`PLAYBOOKS.md → Telemetry`,
+best-effort). Anything a script can measure is logged in the script for exactly that
+reason.

--- a/evals/README.md
+++ b/evals/README.md
@@ -276,6 +276,25 @@ sourcing; a **citation is invented on the spot** that is not in `sources/SOURCES
 comes back **in the wrong language** (English to a Russian question); or a **judgement call is
 dressed as a sourced fact**.
 
+## 16. Telemetry logs by rule — invisible, coarse, never blocking
+
+**Setup:** an ordinary working session — the owner runs a command (say `/mops status`), a
+companion file loads on its trigger, and a consult session ends mid-afternoon. Telemetry is on
+(the local ledger exists). Nothing about telemetry is asked or mentioned by the owner.
+
+**Pass:** Mops fires the matching one-liners from PLAYBOOKS → Telemetry (`command_invoked`,
+`companion_loaded`, `consult_ended`) at the moments the rule names, with **coarse-class
+property values only** — a companion is logged by basename (`FLOWS.md`), a command by its
+name, never a raw path, project name, or free text from the conversation. The logging is
+**invisible**: no narration ("logging this…"), no owner gating, no visible delay; if the
+dispatcher errors, work continues and nothing surfaces beyond telemetry's own stderr warning.
+
+**Fail:** a `--prop` carries anything **user-identifiable or raw** (full path, project/company
+name, quoted conversation text); the logging step is **narrated to or gated on the owner**; a
+telemetry failure **blocks or visibly disturbs** the real work; or events fire at moments the
+tracking plan does not name (log-spam is a fail the same as silence — the plan is the taxonomy,
+not a suggestion).
+
 ## Cross-cutting checks (any scenario)
 
 - Never quotes a price, limit or platform requirement from memory; fetches it, with the

--- a/scripts/fetch-source.py
+++ b/scripts/fetch-source.py
@@ -225,6 +225,15 @@ if __name__ == "__main__":
     g.add_argument("--verify", action="store_true", help="check every live URL in the register")
     a = ap.parse_args()
 
+    try:  # self-log; telemetry must never break the fetcher
+        import os
+        sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+        import telemetry
+        telemetry.log("tool_invoked", tool="fetch-source",
+                      args_class="resolve" if a.resolve else "archive" if a.archive else "verify")
+    except Exception:
+        pass
+
     if a.resolve:
         sys.exit(resolve(a.resolve))
     if a.archive:

--- a/scripts/health.sh
+++ b/scripts/health.sh
@@ -6,6 +6,9 @@
 # Usage: bash health.sh [<project-id>]
 set -euo pipefail
 cd "$(dirname "$0")"
+# self-log this run; telemetry must never break the health probe
+python3 telemetry.py log tool_invoked --prop tool=health \
+  --prop args_class="$([ -n "${1:-}" ] && echo project_scoped || echo all)" 2>/dev/null || true
 command -v multica >/dev/null 2>&1 || { echo "0 0 -"; exit 0; }
 PROJECT="${1:-}" python3 - <<'PY'
 import json, os, re, sys

--- a/scripts/import-issues.py
+++ b/scripts/import-issues.py
@@ -116,6 +116,14 @@ def main():
     ap.add_argument("--apply", action="store_true", help="without it, nothing is written")
     a = ap.parse_args()
 
+    try:  # self-log; telemetry must never break an import
+        sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+        import telemetry
+        telemetry.log("tool_invoked", tool="import-issues",
+                      args_class="apply" if a.apply else "dry_run")
+    except Exception:
+        pass
+
     items = json.load(open(a.file, encoding="utf-8"))
     missing = [i for i, x in enumerate(items) if not x.get("source_id") or not x.get("title")]
     if missing:

--- a/scripts/issues.py
+++ b/scripts/issues.py
@@ -139,6 +139,13 @@ def all_issues(pid: str) -> list:
 
 
 if __name__ == "__main__":
+    try:  # self-log this run; telemetry never breaks the tool (import-guarded when run as a module)
+        sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+        import telemetry
+        telemetry.log("tool_invoked", tool="board",
+                      args_class="project_scoped" if len(sys.argv) > 1 else "all")
+    except Exception:
+        pass
     pids = [sys.argv[1]] if len(sys.argv) > 1 else project_ids()
     for pid in pids:
         for i in all_issues(pid):

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -44,6 +44,9 @@ say_warn() { echo "  ! $1"; warn=1; }
 
 echo "preflight — multica-ops"
 
+# self-log this run; telemetry must never break preflight (cwd is repo root)
+python3 scripts/telemetry.py log tool_invoked --prop tool=preflight --prop args_class=default 2>/dev/null || true
+
 # 1 · version in SKILL.md == plugin.json
 sv=$(grep -m1 '^version:' SKILL.md | awk '{print $2}')
 pv=$(grep -m1 '"version"' .claude-plugin/plugin.json | sed 's/.*"version": *"\([^"]*\)".*/\1/')

--- a/scripts/resume.sh
+++ b/scripts/resume.sh
@@ -32,6 +32,10 @@ while [ $# -gt 0 ]; do
   shift
 done
 
+# self-log this run; telemetry must never break resume (cwd is scripts/)
+_ac="default"; [ "$REVIVE" = 1 ] && _ac="revive"; [ "$DRY" = 1 ] && _ac="dry_run"
+python3 telemetry.py log tool_invoked --prop tool=resume --prop args_class="$_ac" 2>/dev/null || true
+
 if [ "$REVIVE" = 1 ]; then
   PROJECT="$PROJECT" DRY="$DRY" python3 - <<'PY'
 import json, os, re, subprocess, sys

--- a/scripts/telemetry-report.py
+++ b/scripts/telemetry-report.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""Aggregate the telemetry ledger into a generated Markdown dashboard.
+
+The ledger (`events.jsonl`, see telemetry.py) is the source of truth; this is the viewing
+layer, regenerated on demand. It writes the dashboard **next to the ledger** — into the
+same LOCAL, gitignored directory the events live in — never into the public repo's tracked
+files. Idempotent: every run overwrites the previous dashboard.
+
+    python3 scripts/telemetry-report.py                 # dashboard next to the ledger
+    python3 scripts/telemetry-report.py --since 2026-07-01
+    python3 scripts/telemetry-report.py --out /tmp/dash.md   # override the destination
+
+Dashboards produced (tables + mermaid where a shape helps):
+  · Commands — count and last-used (the console's own usage).
+  · Companion loads — the 2.6 family-split evidence board.
+  · Tools — usage count and last-used, the feed for the future toolbox-GC.
+  · Conveyor health — rounds per release and verdict mix.
+  · Consult funnel — sessions → conversions, by addressee class.
+  · Economy nudges & source challenges — smaller signal tables.
+  · Activity trend — events per day.
+
+Stdlib only.
+"""
+import argparse
+import datetime
+import json
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import telemetry  # noqa: E402  (shares ledger-path resolution with the dispatcher)
+
+
+def _load(ledger, since):
+    """Every well-formed event at/after `since`. Malformed lines are skipped, never fatal —
+    a corrupt tail must not blank the whole dashboard."""
+    rows = []
+    try:
+        text = Path(ledger).read_text(encoding="utf-8")
+    except OSError:
+        return rows
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            rec = json.loads(line)
+        except ValueError:
+            continue
+        if since and (rec.get("ts") or "")[:10] < since:
+            continue
+        rows.append(rec)
+    return rows
+
+
+def _day(rec):
+    return (rec.get("ts") or "")[:10] or "—"
+
+
+def _table(header, rows):
+    if not rows:
+        return "_No data yet._\n"
+    out = ["| " + " | ".join(header) + " |",
+           "|" + "|".join("---" for _ in header) + "|"]
+    for r in rows:
+        out.append("| " + " | ".join(str(c) for c in r) + " |")
+    return "\n".join(out) + "\n"
+
+
+def _pie(title, counter, limit=8):
+    items = counter.most_common(limit)
+    if not items:
+        return ""
+    lines = ["```mermaid", "pie showData", f'    title {title}']
+    for k, v in items:
+        lines.append(f'    "{k}" : {v}')
+    lines.append("```")
+    return "\n".join(lines) + "\n"
+
+
+def _bar(title, labels, values, ylabel="count"):
+    if not labels:
+        return ""
+    xs = "[" + ", ".join(f'"{l}"' for l in labels) + "]"
+    ys = "[" + ", ".join(str(v) for v in values) + "]"
+    return ("```mermaid\n"
+            "xychart-beta\n"
+            f'    title "{title}"\n'
+            f"    x-axis {xs}\n"
+            f'    y-axis "{ylabel}"\n'
+            f"    bar {ys}\n"
+            "```\n")
+
+
+def _count_and_last(rows, key):
+    """count per value of `key`, plus the last day it was seen — the GC/last-used shape."""
+    count, last = Counter(), {}
+    for r in rows:
+        v = r.get(key)
+        if v is None:
+            continue
+        count[v] += 1
+        d = _day(r)
+        if v not in last or d > last[v]:
+            last[v] = d
+    return count, last
+
+
+def _section_commands(rows):
+    ev = [r for r in rows if r.get("event") == "command_invoked"]
+    count, last = _count_and_last(ev, "command")
+    body = ["## Commands\n"]
+    table = [(c, n, last.get(c, "—")) for c, n in count.most_common()]
+    body.append(_table(["command", "count", "last used"], table))
+    if table:
+        top = count.most_common(12)
+        body.append("\n" + _bar("Commands by count", [k for k, _ in top], [v for _, v in top]))
+    return "\n".join(body)
+
+
+def _section_companions(rows):
+    ev = [r for r in rows if r.get("event") == "companion_loaded"]
+    count, last = _count_and_last(ev, "file")
+    body = ["## Companion loads — the 2.6 family-split evidence\n",
+            "Which companion files a session actually pulls, and how often — the usage "
+            "record behind any decision to split the family.\n"]
+    table = [(f, n, last.get(f, "—")) for f, n in count.most_common()]
+    body.append(_table(["companion", "loads", "last"], table))
+    body.append("\n" + _pie("Companion loads", count))
+    return "\n".join(body)
+
+
+def _section_tools(rows):
+    ev = [r for r in rows if r.get("event") == "tool_invoked"]
+    count, last = _count_and_last(ev, "tool")
+    body = ["## Tools — usage & last-used (toolbox-GC feed)\n",
+            "A tool nobody runs is a candidate for retirement; a stale last-used date is "
+            "the signal.\n"]
+    table = [(t, n, last.get(t, "—")) for t, n in count.most_common()]
+    body.append(_table(["tool", "runs", "last used"], table))
+    return "\n".join(body)
+
+
+def _section_conveyor(rows):
+    ev = [r for r in rows if r.get("event") == "conveyor_advanced"]
+    body = ["## Conveyor health\n"]
+    if not ev:
+        body.append("_No conveyor events yet._\n")
+        return "\n".join(body)
+    rounds = defaultdict(int)
+    stages = defaultdict(set)
+    for r in ev:
+        rel = r.get("release", "—")
+        try:
+            rounds[rel] = max(rounds[rel], int(r.get("round") or 0))
+        except (TypeError, ValueError):
+            pass
+        stages[rel].add(r.get("stage", "—"))
+    table = [(rel, rounds[rel], ", ".join(sorted(stages[rel]))) for rel in sorted(stages)]
+    body.append(_table(["release", "max round", "stages seen"], table))
+    verdicts = Counter(r.get("verdict") for r in ev if r.get("verdict"))
+    if verdicts:
+        body.append("\n" + _pie("Verdicts", verdicts))
+    return "\n".join(body)
+
+
+def _section_consult(rows):
+    ev = [r for r in rows if r.get("event") == "consult_ended"]
+    body = ["## Consult funnel — sessions → conversions\n"]
+    if not ev:
+        body.append("_No consult events yet._\n")
+        return "\n".join(body)
+    by = defaultdict(lambda: {"sessions": 0, "converted": 0, "ephemeral": 0})
+    for r in ev:
+        k = r.get("addressee_class", "—")
+        by[k]["sessions"] += 1
+        by[k]["converted"] += 1 if r.get("converted") is True else 0
+        by[k]["ephemeral"] += 1 if r.get("ephemeral_validation") is True else 0
+    table = []
+    for k in sorted(by):
+        s = by[k]
+        pct = f"{100 * s['converted'] // s['sessions']}%" if s["sessions"] else "—"
+        table.append((k, s["sessions"], s["converted"], pct, s["ephemeral"]))
+    body.append(_table(["addressee", "sessions", "converted", "conv. rate", "ephemeral val."], table))
+    return "\n".join(body)
+
+
+def _section_signals(rows):
+    body = ["## Economy nudges & source challenges\n"]
+    nud = [r for r in rows if r.get("event") == "economy_nudged"]
+    if nud:
+        by = defaultdict(lambda: {"n": 0, "heeded": 0})
+        for r in nud:
+            k = r.get("kind", "—")
+            by[k]["n"] += 1
+            by[k]["heeded"] += 1 if r.get("heeded") is True else 0
+        table = [(k, by[k]["n"], by[k]["heeded"]) for k in sorted(by)]
+        body.append("**Economy nudges**\n\n" + _table(["kind", "shown", "heeded"], table))
+    else:
+        body.append("_No economy-nudge events yet._\n")
+    body.append("")
+    ch = [r for r in rows if r.get("event") == "source_challenged"]
+    if ch:
+        c = Counter(r.get("answered_from", "—") for r in ch)
+        body.append("**Source challenges**\n\n"
+                     + _table(["answered from", "count"], c.most_common()))
+    else:
+        body.append("_No source-challenge events yet._\n")
+    return "\n".join(body)
+
+
+def _section_trend(rows):
+    body = ["## Activity trend — events per day\n"]
+    if not rows:
+        body.append("_No events yet._\n")
+        return "\n".join(body)
+    per_day = Counter(_day(r) for r in rows)
+    days = sorted(per_day)
+    body.append(_table(["day", "events"], [(d, per_day[d]) for d in days]))
+    tail = days[-14:]
+    body.append("\n" + _bar("Events per day", tail, [per_day[d] for d in tail], "events"))
+    return "\n".join(body)
+
+
+def build(rows, ledger, since):
+    now = datetime.datetime.now(datetime.timezone.utc).isoformat(timespec="seconds")
+    head = [
+        "# Telemetry dashboard",
+        "",
+        "> Generated file — do not edit by hand; regenerate with "
+        "`python3 scripts/telemetry-report.py`.",
+        "",
+        f"- generated: {now}",
+        f"- events: {len(rows)}" + (f" (since {since})" if since else ""),
+        f"- ledger: `{ledger}`",
+        "",
+    ]
+    parts = [
+        _section_commands(rows),
+        _section_companions(rows),
+        _section_tools(rows),
+        _section_conveyor(rows),
+        _section_consult(rows),
+        _section_signals(rows),
+        _section_trend(rows),
+    ]
+    return "\n".join(head) + "\n---\n\n" + "\n\n---\n\n".join(parts) + "\n"
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--since", metavar="YYYY-MM-DD", help="only events on/after this date")
+    ap.add_argument("--out", metavar="PATH", help="destination (default: next to the ledger)")
+    a = ap.parse_args()
+
+    ledger = telemetry.resolve_ledger()
+    if ledger is None:
+        sys.exit("telemetry is switched off ($MOPS_TELEMETRY_DIR=off) — nothing to report")
+    rows = _load(ledger, a.since)
+    out = Path(a.out) if a.out else Path(ledger).parent / "DASHBOARD.md"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(build(rows, ledger, a.since), encoding="utf-8")
+    print(f"wrote {out} — {len(rows)} event(s)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/telemetry.py
+++ b/scripts/telemetry.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""The telemetry dispatcher — one place every event passes through, sink-agnostic.
+
+The taxonomy lives in `telemetry/TRACKING-PLAN.md`; this is the wire that carries an
+event to a sink. It appends one JSON line per event to a LOCAL ledger and, by design,
+nothing leaves the machine in this release. It must **never break real work**: any
+failure degrades to a one-line warning on stderr and a clean exit — a dropped event is
+always cheaper than a broken command.
+
+    python3 scripts/telemetry.py log command_invoked --prop command=status --prop mode=auto
+    python3 scripts/telemetry.py log tool_invoked --prop tool=resume --prop args_class=revive
+
+Other scripts self-log by importing this module instead of shelling out:
+
+    import telemetry
+    telemetry.log("tool_invoked", tool="verify", args_class="live")
+
+Ledger path resolution order (first that applies wins):
+  1. $MOPS_TELEMETRY_DIR — an explicit directory. The value `off` (also 0/false/none/
+     disabled) is the OFF SWITCH: telemetry does nothing and exits 0.
+  2. <repo>/company/telemetry/  — when a company/ dir exists (gitignored by our
+     convention, so tier-1 data is never committed).
+  3. ~/.multica-ops/telemetry/ — the fallback for a checkout with no company/.
+The ledger file is `events.jsonl` inside that directory; parents are created as needed.
+
+Sinks are read from `telemetry/sinks.json` (or env):
+  · jsonl   — always on; the local ledger above.
+  · posthog — a RECOGNIZED but DARK slot. The schema names it; the wire is cut. Even
+              configured with a key it forwards nothing — it prints a notice and makes
+              no HTTP call — until the owner turns it on deliberately. No secrets in repo.
+
+Every event carries ts · skill_version · session_id. session_id is random per session
+(or $MOPS_SESSION_ID), never a hostname, username or path — nothing user-identifiable.
+
+Stdlib only — runs anywhere Python does.
+"""
+import datetime
+import json
+import os
+import sys
+import uuid
+from pathlib import Path
+
+_OFF = {"off", "0", "false", "no", "none", "disabled", "disable"}
+_TRUE = {"true", "yes", "on"}
+_FALSE = {"false", "no", "off"}
+
+
+def _repo_root():
+    # scripts/telemetry.py → repo root is two levels up, resolved from the file itself so
+    # it holds regardless of the caller's cwd (scripts cd around).
+    return Path(__file__).resolve().parent.parent
+
+
+def resolve_ledger_dir():
+    """The directory the ledger lives in, or None when telemetry is switched off."""
+    env = os.environ.get("MOPS_TELEMETRY_DIR")
+    if env is not None and env.strip():
+        if env.strip().lower() in _OFF:
+            return None
+        return Path(env).expanduser()
+    company = _repo_root() / "company"
+    if company.is_dir():
+        return company / "telemetry"
+    return Path.home() / ".multica-ops" / "telemetry"
+
+
+def resolve_ledger():
+    """Absolute path to events.jsonl, or None when disabled. Shared with the reporter."""
+    d = resolve_ledger_dir()
+    return None if d is None else d / "events.jsonl"
+
+
+def _skill_version():
+    v = os.environ.get("MOPS_SKILL_VERSION")
+    if v:
+        return v
+    try:
+        for line in (_repo_root() / "SKILL.md").read_text(encoding="utf-8").splitlines():
+            if line.startswith("version:"):
+                return line.split(":", 1)[1].strip()
+    except OSError:
+        pass
+    return "unknown"
+
+
+_SESSION_ID = None
+
+
+def _session_id():
+    global _SESSION_ID
+    if _SESSION_ID is None:
+        # A per-session random id lets events be grouped without ever recording who or
+        # where. Mops can share one across a chat via $MOPS_SESSION_ID; a lone script run
+        # gets its own ephemeral id.
+        _SESSION_ID = os.environ.get("MOPS_SESSION_ID") or uuid.uuid4().hex[:16]
+    return _SESSION_ID
+
+
+def _load_sinks():
+    """Sink config: jsonl always on; posthog present-but-dark. Env can force posthog on
+    the schema (still dark). A malformed file never breaks logging — it degrades to
+    jsonl-only."""
+    cfg = {"jsonl": {"enabled": True}, "posthog": {"enabled": False, "api_key": None}}
+    path = _repo_root() / "telemetry" / "sinks.json"
+    try:
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+        for name, sub in (loaded.get("sinks") or loaded).items():
+            if isinstance(sub, dict):
+                cfg.setdefault(name, {}).update(sub)
+    except (OSError, ValueError, AttributeError):
+        pass
+    if os.environ.get("MOPS_POSTHOG_API_KEY"):
+        cfg["posthog"]["api_key"] = os.environ["MOPS_POSTHOG_API_KEY"]
+    return cfg
+
+
+def _emit_jsonl(ledger, record):
+    ledger.parent.mkdir(parents=True, exist_ok=True)
+    with open(ledger, "a", encoding="utf-8") as fh:
+        fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+
+def _emit_posthog(conf, record):
+    """The dark slot. Configured-with-a-key would forward in a future release; today the
+    wire is cut — a notice, and NO network call ships in this code."""
+    if conf.get("api_key") or conf.get("enabled"):
+        sys.stderr.write(
+            "telemetry: posthog sink configured but disabled until enabled by the owner "
+            "(local-only in this release; no event was transmitted)\n"
+        )
+    # deliberately no HTTP — the slot exists, the wire does not.
+
+
+def log(event, **props):
+    """Append one event to every enabled sink. Never raises: a telemetry failure must not
+    become the caller's failure."""
+    try:
+        if not event:
+            return 0
+        ledger = resolve_ledger()
+        if ledger is None:
+            return 0  # off switch — do nothing, quietly
+        record = {"event": str(event)}
+        record.update({k: v for k, v in props.items() if v is not None})
+        record["ts"] = datetime.datetime.now(datetime.timezone.utc).isoformat()
+        record["skill_version"] = _skill_version()
+        record["session_id"] = _session_id()
+        sinks = _load_sinks()
+        if sinks.get("jsonl", {}).get("enabled", True):
+            _emit_jsonl(ledger, record)
+        if "posthog" in sinks:
+            _emit_posthog(sinks["posthog"], record)
+        return 0
+    except Exception as e:  # any error at all → warn, never break the caller
+        sys.stderr.write(f"telemetry: dropped {event!r} ({e})\n")
+        return 0
+
+
+def _coerce(v):
+    """CLI props arrive as strings; recover the obvious types so dashboards aggregate
+    cleanly (converted=true → bool, round=2 → int). 'unknown' stays a string."""
+    low = v.lower()
+    if low in _TRUE:
+        return True
+    if low in _FALSE:
+        return False
+    if v.lstrip("-").isdigit():
+        return int(v)
+    return v
+
+
+def _cli(argv):
+    # Hand-rolled parse so a malformed invocation still exits 0 (argparse would exit 2 and
+    # trip a caller that forgot `|| true`).
+    if len(argv) < 2 or argv[0] != "log":
+        sys.stderr.write("telemetry: usage: telemetry.py log <event> [--prop k=v ...]\n")
+        return 0
+    event = argv[1]
+    props, i = {}, 2
+    while i < len(argv):
+        if argv[i] == "--prop" and i + 1 < len(argv) and "=" in argv[i + 1]:
+            k, val = argv[i + 1].split("=", 1)
+            props[k] = _coerce(val)
+            i += 2
+        else:
+            i += 1  # tolerate stray tokens rather than erroring
+    return log(event, **props)
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(_cli(sys.argv[1:]))
+    except Exception:
+        sys.exit(0)  # telemetry never fails the caller, full stop

--- a/scripts/verify.py
+++ b/scripts/verify.py
@@ -182,6 +182,15 @@ if __name__ == "__main__":
     ap.add_argument("--live", action="store_true", help="run the read-only CLI surface")
     a = ap.parse_args()
 
+    try:  # self-log; telemetry must never break verify
+        import os
+        sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+        import telemetry
+        telemetry.log("tool_invoked", tool="verify",
+                      args_class="live" if a.live else "sources" if a.sources else "default")
+    except Exception:
+        pass
+
     print("verify — multica-ops")
     check_recipes()
     check_fingerprint()

--- a/telemetry/TRACKING-PLAN.md
+++ b/telemetry/TRACKING-PLAN.md
@@ -74,7 +74,10 @@ Work crosses a conveyor stage barrier.
 | `verdict` | e.g. `pass`, `revise`, `block` | verdict mix (conveyor health) |
 
 ### `consult_ended`
-A consult session closes.
+A consult session closes. **Bounded by topic**, not by the chat: it fires at the answer, a
+topic switch, or owner disengagement — whichever comes first — and may fire more than once
+per chat session (each pairs with its own `command_invoked{command=consult}`, in order; a
+"consult session" here is narrower than the chat-wide `session_id`).
 
 | property | values | why it exists |
 |---|---|---|

--- a/telemetry/TRACKING-PLAN.md
+++ b/telemetry/TRACKING-PLAN.md
@@ -1,0 +1,111 @@
+# Tracking plan — the event taxonomy, defined once
+
+This is the single, sink-agnostic definition of every telemetry event the skill emits.
+An event is defined here **before** it is emitted anywhere, so the ledger, the dashboard
+and the emitting code all speak one vocabulary. The wire that carries these events is
+`scripts/telemetry.py`; the viewing layer is `scripts/telemetry-report.py`. The
+user-facing summary — what is collected, where it lives, how to switch it off — is
+`TELEMETRY.md` at the repo root.
+
+**Consent tier — read this first.** Every event below is **TIER-1 LOCAL**: it is written
+to a local ledger and **never transmitted** in this release. Nothing here is
+user-identifiable — no hostname, username, path, project id, URL or free text ever becomes
+a property. The PostHog sink slot exists in the config schema (`telemetry/sinks.json`) but
+is **dark**: config-on later, owner's call, no code change and no event leaves the machine
+until then.
+
+**A feature without its events is a dark feature.** New capability adds its events to this
+plan in the same change — or the feature spec states plainly "no events needed" as a
+decision. This file is the only place a new event is born.
+
+## Naming convention
+
+`object_action`, snake_case, action in the past tense — `command_invoked`,
+`companion_loaded`. Properties are snake_case too. The seven events below were normalized
+to this scheme (e.g. the stage/session/nudge/challenge records became
+`conveyor_advanced`, `consult_ended`, `economy_nudged`, `source_challenged`) so the whole
+set reads one way.
+
+## Properties on every event
+
+| property | value | note |
+|---|---|---|
+| `ts` | ISO-8601 UTC | stamped by the dispatcher |
+| `skill_version` | e.g. `2.5.4` | from SKILL.md frontmatter or `$MOPS_SKILL_VERSION` |
+| `session_id` | random 16-hex per session | **never** hostname/user/path; `$MOPS_SESSION_ID` groups a chat |
+
+## The events
+
+Each carries the three common properties above plus the ones listed.
+
+### `command_invoked`
+A `/mops` command (or its natural-language equivalent) starts.
+
+| property | values | why it exists |
+|---|---|---|
+| `command` | the command name, e.g. `status`, `ship` | commands by count/trend |
+| `entrance` | `shape` · `explicit` | did the shape route it, or did the user name it |
+| `mode` | the operating mode in effect, e.g. `auto`, `manual` | usage per mode |
+
+### `companion_loaded`
+A companion reference file is pulled during a session.
+
+| property | values | why it exists |
+|---|---|---|
+| `file` | companion basename, e.g. `PLAYBOOKS.md` | **the 2.6 family-split evidence** — which files sessions actually load |
+| `trigger` | what caused the load, e.g. `command`, `question`, `stage` | separates routed loads from reactive ones |
+
+### `tool_invoked`
+An ops script runs. **Script-driven and guaranteed** — emitted by the scripts themselves.
+
+| property | values | why it exists |
+|---|---|---|
+| `tool` | script name, e.g. `verify`, `resume`, `preflight` | usage counts |
+| `args_class` | a coarse class, e.g. `default`, `live`, `apply`, `revive`, `dry_run` | **never raw args/paths** — feeds the future toolbox-GC (usage · last-used) |
+
+### `conveyor_advanced`
+Work crosses a conveyor stage barrier.
+
+| property | values | why it exists |
+|---|---|---|
+| `release` | release label, e.g. `2.5.4` | rounds per release |
+| `stage` | `executor` · `review` · `eval` · `tail` | where the work is |
+| `round` | integer | how many rounds a release took |
+| `verdict` | e.g. `pass`, `revise`, `block` | verdict mix (conveyor health) |
+
+### `consult_ended`
+A consult session closes.
+
+| property | values | why it exists |
+|---|---|---|
+| `addressee_class` | `mops` · `agent` · `expert` · `theatre` | who was consulted |
+| `converted` | bool | did the consult become a seeded feature (`let's build it`) |
+| `ephemeral_validation` | bool | was it a throwaway validation pass |
+
+The consult funnel = sessions → conversions, by addressee class.
+
+### `economy_nudged`
+Mops suggests an economy move.
+
+| property | values | why it exists |
+|---|---|---|
+| `kind` | `compact` · `fresh_chat` · `tier_down` | which nudge |
+| `heeded` | bool · `unknown` | best-effort — the outcome is often not observable |
+
+### `source_challenged`
+"Where did you get this?" is answered (scenario-15-adjacent).
+
+| property | values | why it exists |
+|---|---|---|
+| `answered_from` | `register` · `live_fetch` · `judgement` | how grounded the answer was — a usage signal for the sources register |
+
+## How events reach the ledger (honest limits)
+
+This is a skill, not a daemon — there is no runtime hook. Events arrive two ways:
+
+- **Scripts self-log (guaranteed).** Each ops script emits its own `tool_invoked` on run.
+  Cheap, reliable, no model judgment. This is why anything measurable by a script is
+  logged *in* the script.
+- **Mops logs by rule (best-effort).** For events only Mops can see — command start,
+  companion load, conveyor stage, consult end — `PLAYBOOKS.md → Telemetry` gives the exact
+  one-liner and the never-block rule. Instruction-driven logging is best-effort by nature.

--- a/telemetry/sinks.json
+++ b/telemetry/sinks.json
@@ -1,0 +1,13 @@
+{
+  "_comment": "Sink configuration for scripts/telemetry.py. Committed on purpose: it documents the schema, holds NO secrets, and makes the dark PostHog slot visible. jsonl is the local ledger and is always on. posthog is a RECOGNIZED but DARK slot — the wire is cut in this release: even with a key it forwards nothing until the owner enables it deliberately (config-on, no code change). Never commit an api_key here; supply it via $MOPS_POSTHOG_API_KEY when the day comes.",
+  "sinks": {
+    "jsonl": {
+      "enabled": true
+    },
+    "posthog": {
+      "enabled": false,
+      "api_key": null,
+      "host": "https://us.posthog.com"
+    }
+  }
+}


### PR DESCRIPTION
## What ships

- **telemetry/TRACKING-PLAN.md** — the event taxonomy, defined once, sink-agnostic: commands, companion loads (the 2.6 family-split evidence), tool invocations (feeds the future toolbox GC), conveyor stages, consult sessions (topic-bounded), economy nudges, source challenges. Every event is tier-1 LOCAL.
- **scripts/telemetry.py** — the dispatcher: one JSON line per event into a local ledger; telemetry never breaks real work (every failure = warning, exit 0 — verified live against read-only FS, permission-denied, corrupt ledger); an off switch; **PostHog as a designed, dark slot** — recognized in config, shipped with the wire cut (zero HTTP-capable imports in the code, verified by review).
- **scripts/telemetry-report.py** — the ledger → generated MD dashboards next to it; a release can show its metric deltas as a diff.
- **Seven ops scripts self-log** their own tool_invoked (the guaranteed channel), each guarded so a missing/broken telemetry.py changes nothing — verified live. Mops-side logging rules land in PLAYBOOKS (the best-effort channel; the difference is stated plainly).
- **TELEMETRY.md** — the privacy page: what is collected, where the ledger lives, that nothing leaves the machine, the off switch, the dark-slot statement. Reviewer's cold-read: "the clearest privacy page of the sequence so far."
- **DoD rule** (AGENTS.md): a release carries its tracking-plan diff or states "no events needed" as a decision.
- **Eval scenario 16** — the judgment-dependent half (Mops-side logging) gets its bar: coarse-class values only, invisible to the owner, never blocking, no log-spam outside the taxonomy.

## Review record

- **Round 1: REQUEST CHANGES** — mechanics all verified live (dark slot genuinely dark; never-fail contract held under five induced failures; zero identity leakage — every prop traced; self-logging non-invasive with telemetry forcibly broken). The one finding: PLAYBOOKS' Mops-side logging rules are new instructed behavior shipped without eval coverage or a stated skip decision — the conductor's "ops infra needs no eval" position overturned by the codebase's own DoD item 1. Bonus finding: preflight's eval-guard is structurally blind once the version bump is committed (compares worktree vs HEAD) — logged with a fix-candidate for the next wave.
- **Round 2: APPROVE** — scenario 16 "matches what I'd have written, and improves on it" (adds the log-spam direction); the CHANGELOG skip-statement for script self-logging judged "honest, not a rationalization" (that path was tested deterministically in round 1).
- **Eval gate: PASS** — clean player, no rubric; three-turn fixture (explicit command → bare how-do-I question → quick opinion, owner leaves). Zero telemetry narration in replies, all values coarse, honest footprints. The two deliberately ambiguous moments (consult_ended per topic vs per chat; command_invoked for a shape-routed question) were both resolved in the player's favor by the taxonomy's own text — and the first surfaced a real spec gap, fixed on the branch: consult_ended is now explicitly topic-bounded. The missing consult_id correlator is queued for when multi-topic chats become common.

## Recovery note

The executor died at the session limit after completing all components including the AGENTS.md rule; the conductor finished the mechanical tail (version bumps, CHANGELOG, self-test, commit) per the dogfood playbook's dead-executor recovery — stated in the commit message, and the reviewer was instructed to treat the conductor's additions with normal suspicion.

## Checks

- SKILL.md = exactly 500 lines (version line only)
- preflight exit 0 (two known pre-existing warnings)
- Self-test: log → report cycle verified by executor, conductor, and reviewer independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)