### PR TITLE
Roadmap section trimmed to the forward-only rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,19 +168,8 @@ binary.
 
 ## Roadmap
 
-What's next, roughly in order — a teaser, not a backlog. This list is **forward-only**: when
-something ships it leaves here (it's then described above and in the changelog), so nothing is
-ever shown as "done" twice.
-
-- [ ] **Memory system** — provenance-tagged, per-human recall the team rebuilds from the repo.
-- [ ] **Architecture review + a modular skill family** — split the core, budget what's always loaded.
-- [ ] **Product Atlas** — a living product dossier, with personas walking captured flows.
-- [ ] **`/mops explore`** — surface-captures a live product into repo-stored maps (steps + screenshots).
-- [ ] **`/report`** — structured feedback back to the platform, not just a chat message.
-- [ ] **Pipelines-as-projects** — a run with a contract (cadence · dry-run · idempotency · stop conditions), not feature acceptance criteria.
-- [ ] **Multi-instance** — one Mops across many workspaces, cleanly separated.
-
-Order and scope can change; the **CHANGELOG** is the record of what actually shipped.
+The skill is feature-complete for its current shape; maintenance and fixes continue. The
+**CHANGELOG** is the record of what actually shipped.
 
 ## What Mops handles
 


### PR DESCRIPTION
The README roadmap listed items that are no longer tracked here. Trimmed to the forward-only rule: what shipped lives in the body of the README and in the CHANGELOG, never as a checked box — nothing is shown as done twice.