### PR TITLE
Unfreeze: the corpus no longer claims the skill is done

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.5.5
 
-**Five hygiene fixes and a plain-language pass on the word "telemetry" — the last feature-bearing release before the skill freezes to maintenance**
+**Five hygiene fixes and a plain-language pass on the word "telemetry"**
 
 - **Repo visibility is stated at creation.** When Mops creates a repository it now says the
   visibility out loud — *"creating it private"* — so private-by-default is visible, not

--- a/README.md
+++ b/README.md
@@ -168,8 +168,8 @@ binary.
 
 ## Roadmap
 
-The skill is feature-complete for its current shape; maintenance and fixes continue. The
-**CHANGELOG** is the record of what actually shipped.
+Forward-only: what shipped lives in the body of this file and in the **CHANGELOG**, never as
+a checked box here. The CHANGELOG is the record — and the migration map `/mops upgrade` reads.
 
 ## What Mops handles
 


### PR DESCRIPTION
Two public sentences claimed a future the owner had not called:

- `CHANGELOG.md` 2.5.5 headline — *"the last feature-bearing release before the skill freezes to maintenance"*
- `README.md` Roadmap — *"The skill is feature-complete for its current shape; maintenance and fixes continue."*

Both removed. The 2.5.5 headline keeps what the release actually shipped; the README roadmap now states the forward-only rule instead of a status.

Correcting a forward-looking claim that was never true is not rewriting a released entry's substance (AGENTS.md, *Writing the changelog*) — nothing about what shipped changed.

**Also done outside this diff, on the public surfaces:**
- Release [v2.5.5](https://github.com/jamillazarev/multica-ops/releases/tag/v2.5.5) — title *"Final hygiene"* → *"Hygiene pass"*; the *"settles into maintenance"* lead line dropped.
- PR #14 — same two edits to title and lead line.
- Docs site — regenerated; the changelog page carried the same sentence.

**Left alone:** PR #13's body records the owner's own roadmap-trim call ("development continues in a separate workspace"). That states where work happens, not that the skill is frozen — say the word and it goes too.

preflight green (one pre-existing warning: local CLI v0.4.7 behind the v0.4.8 pin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)