### PR TITLE
2.6.1 — two agents disagreeing get the ceiling the review gate already had

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "multica-ops",
   "description": "Mops (Executive Advisor) for Multica: builds and runs an autonomous company of AI agents — interview, bootstrap, conveyor, console.",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "license": "Apache-2.0",
   "author": {
     "name": "Jamil Lazarev",

--- a/BOOTSTRAP.md
+++ b/BOOTSTRAP.md
@@ -128,7 +128,15 @@ multica agent create --name "<Role name>" --model <model-id> --runtime-id <rt> \
   --description "<one line>" --instructions "<role system prompt>" --output json
 multica agent avatar <agent-id> --file <png>       # see ROLES.md → Avatars
 multica agent update <agent-id> --model <…> --instructions "<…>"
+multica agent copy <source-agent-id> --name "<Role name>"   # a near-twin: fork, don't retype
 ```
+**A second agent almost like an existing one is a `copy`, not a re-typed `create`** (CLI v0.4.12).
+It carries instructions, description, avatar, permission mode and allow-list, attached skills,
+`max_concurrent_tasks`, and — only while the runtime is unchanged — model, thinking level and
+service tier. **Secrets never travel**: `custom_env`, `mcp_config` and `runtime_config` are not
+copied, which is the behaviour you want; supply fresh values with the same secret-safe flags as
+`create`. Forking onto a different runtime (`--runtime-id`) **requires `--model`** (`--model ""`
+takes the target's default) and drops thinking level and service tier unless you set them.
 - **Profession-style names** ("QA Engineer", "Product Manager") — clearer in mentions.
 - **Model tiering is mandatory** — see §7: not every role needs the top model.
 - `agent update` takes a **UUID**, not a name.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## 2.6.1
+
+**Two agents disagreeing had no ceiling — now they have the one the review gate already used**
+
+- **A disagreement between agents is bounded at two exchanges.** The three-round rule existed,
+  but only for a *review* bounced a third time and for one agent grinding three times at one
+  error. Two capable agents arguing in a task thread fitted neither, so nothing stopped it —
+  and thread rotation is a **storage** event, so the spend is already gone by the time a long
+  thread notices itself. The ceiling now generalizes, and so does the diagnosis: **a third pass
+  on one point means the brief admits both readings**, not that someone is wrong.
+- **It escalates as a comment on the issue, not as more thread** — a thread dies with its run
+  and *"as discussed above"* is not a spec. The escalation carries the **ambiguous line and both
+  readings with what each costs**; *"they couldn't agree"* is sent back, because a summary of an
+  argument makes the next person re-run it.
+- **It is settled by editing the artifact** — spec, DoD or acceptance criteria, in that same
+  task — so nobody re-argues it next week. It stops at the first rung that can make that edit,
+  usually the conductor; crew mode ends at the owner, who already holds the third-review-round
+  call.
+- **The ceiling is priced, not just counted.** `@`-mentioning an agent is a run that spends
+  budget, so "this point cost N runs" is ordinary grouping rather than an estimate — a limit
+  counted only in rounds is a wish.
+- **CLI map re-pinned to v0.4.12**, and the surface gained something worth using: **`agent copy`**
+  forks an existing agent's portable config into a new one — instructions, description, avatar,
+  permission mode and allow-list, attached skills, concurrency, and (same runtime only) model and
+  thinking level. **Secrets deliberately do not travel** — `custom_env`, `mcp_config`,
+  `runtime_config` are never copied. So a second agent almost like an existing one is a fork, not
+  a retyped `create` (BOOTSTRAP §2). Closes #15.
+- The rule ships in **`templates/GUIDE-template.md`**, because the disputants are agents: a rule
+  only Mops can read governs only the tasks Mops is in. Anti-patterns generalized in REFERENCE
+  §8, the operating recipe in PLAYBOOKS, and eval scenario **17** covers it.
+
+
 ## 2.6.0
 
 **The repo layout is written down as one table, the two documents that had two homes get one, and the telemetry subsystem is removed**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,14 @@
   thinking level. **Secrets deliberately do not travel** — `custom_env`, `mcp_config`,
   `runtime_config` are never copied. So a second agent almost like an existing one is a fork, not
   a retyped `create` (BOOTSTRAP §2). Closes #15.
+- **Stopping the loop is free; arguing is not.** The halt is a status change — `blocked` plus a
+  comment, since a comment wakes nobody (only assignment, `@`-mention, chat and autopilot are
+  triggers) — never an `@`-mention, which is itself a run: spending two more runs to stop spending
+  runs is the one trade nobody meant to make.
+- **Settling a dispute is not a licence to move the bar.** The spec and the task's wording are
+  editable in flight; the **DoD and acceptance criteria are locked** — proposed to the owner,
+  never edited by whoever is measured against them, and that includes the conductor and Mops.
+  Most spec disputes turn out to be DoD disputes, so this is the common case.
 - The rule ships in **`templates/GUIDE-template.md`**, because the disputants are agents: a rule
   only Mops can read governs only the tasks Mops is in. Anti-patterns generalized in REFERENCE
   §8, the operating recipe in PLAYBOOKS, and eval scenario **17** covers it.

--- a/PLAYBOOKS.md
+++ b/PLAYBOOKS.md
@@ -588,14 +588,22 @@ admitted both readings.
 
 What Mops (or whoever holds the rung above them) does:
 
-1. **Stop it at the third exchange**, and say why in one line — the ceiling is a rule, not a
-   mood, so nobody has to decide whether this argument "feels long enough".
+1. **Stop it at the third exchange, and stop it for free** — set the issue `blocked` and say why
+   in one line. A comment wakes nobody (REFERENCE §2: only assignment, `@`-mention, chat and
+   autopilot do), so the **status** is what halts round four and the comment only explains it.
+   `@`-mentioning to call the halt spends two more runs to stop spending runs. The ceiling is a
+   rule, not a mood, so nobody has to decide whether an argument "feels long enough".
 2. **Read the escalation for the ambiguity, not the verdict.** A good escalation names the
    line and both readings with what each costs; *"they couldn't agree"* is not one — send it
    back for the question, since a summary of an argument makes the next person re-run it.
-3. **Settle it by editing the artifact**, not by picking a side in the thread: the spec, the DoD,
-   or the acceptance criteria in **that same task** (docs-follow-decisions). A verdict that lives
-   only in a comment is re-litigated the next time someone reads the issue without the thread.
+3. **Settle it by fixing the artifact**, not by picking a side in the thread — and mind which
+   artifact. The **spec and the task's wording** are editable in flight: correct them in **that
+   same task** (docs-follow-decisions), because a verdict living only in a comment is re-litigated
+   the next time someone reads the issue without the thread. The **DoD and acceptance criteria are
+   locked** — proposed to the owner, never edited by whoever is measured against them, and that
+   bar includes the conductor and Mops. Most spec disputes turn out to be DoD disputes, so this is
+   the common case, not the exception: Mops brings the owner **one** settled wording, not two
+   competing ones.
 4. **Price it.** `@`-mentioning an agent is a run that spends budget, so the runs on that issue
    *are* the bill — "this point cost six runs" is a grouping, not an estimate. Report it with the
    fix; a ceiling nobody prices drifts back up.

--- a/PLAYBOOKS.md
+++ b/PLAYBOOKS.md
@@ -32,6 +32,7 @@ control characters that break `json.loads` — sanitize with
 - [Human onboarding / offboarding](#human-onboarding-offboarding)
 - [Cost/effort ledger (at /ship and /measure)](#costeffort-ledger-at-ship-and-measure)
 - [Resident Mops — install / refresh](#resident-mops-install-refresh)
+- [Two agents disagree — settle the spec, not the argument](#two-agents-disagree-settle-the-spec-not-the-argument)
 - [Fixing an agent that keeps getting it wrong](#fixing-an-agent-that-keeps-getting-it-wrong)
 - [Skill load per agent (in /audit)](#skill-load-per-agent-in-audit)
 - [Utilization review (in /audit, or on a leader's request)](#utilization-review-in-audit-or-on-a-leaders-request)
@@ -576,6 +577,39 @@ second copy. Then `agent create` (name **Mops**) → `agent skills` attach (+ fi
 → `agent avatar` per chosen library (Mops in Multica keeps `assets/mops-avatar.png`) → subtitle "Executive Advisor · resident" → rights
 per autonomy choice → kickoff (pinned issue + first message = decisions summary).
 
+
+## Two agents disagree — settle the spec, not the argument
+
+A disagreement in a task thread is bounded like every other loop in this skill: **two exchanges
+on one point, and the third is a signal rather than another opinion.** The diagnosis is the same
+one the review gate already uses — **a third pass on the same point means the brief is
+ambiguous**, not that one of them is wrong. Two capable agents arguing usually means the task
+admitted both readings.
+
+What Mops (or whoever holds the rung above them) does:
+
+1. **Stop it at the third exchange**, and say why in one line — the ceiling is a rule, not a
+   mood, so nobody has to decide whether this argument "feels long enough".
+2. **Read the escalation for the ambiguity, not the verdict.** A good escalation names the
+   line and both readings with what each costs; *"they couldn't agree"* is not one — send it
+   back for the question, since a summary of an argument makes the next person re-run it.
+3. **Settle it by editing the artifact**, not by picking a side in the thread: the spec, the DoD,
+   or the acceptance criteria in **that same task** (docs-follow-decisions). A verdict that lives
+   only in a comment is re-litigated the next time someone reads the issue without the thread.
+4. **Price it.** `@`-mentioning an agent is a run that spends budget, so the runs on that issue
+   *are* the bill — "this point cost six runs" is a grouping, not an estimate. Report it with the
+   fix; a ceiling nobody prices drifts back up.
+5. **If the same two disagree twice on different points**, the defect is upstream of both: their
+   briefs overlap, or one owns a decision the other is being asked to make. That is a routing
+   fix (`/mops squad`), not another settlement.
+
+**Where it escalates.** Up the standing chain — agent → squad leader → conductor → Mops → owner —
+and **it stops at the first rung that can edit the spec**, which is usually the conductor. Crew
+mode has no conductor, so it ends at the owner, who already holds the third-review-round call.
+
+**Never let it ride on thread length.** A thread that gets long enough to rotate is a storage
+event, not a cost control: the spend has already happened by then, and the argument is invisible
+to anyone reading the issue afterwards.
 
 ## Fixing an agent that keeps getting it wrong
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ parts worth trusting are the ones you can check:
 - **Honest about the ceiling.** The caps are stated, not wished away: **6 tasks per agent, 20 per
   daemon** (the tighter wins), a `local_directory` serialises regardless, and `workspace delete`
   isn't in the CLI — so Mops says so instead of promising it. Every number carries its check-date.
-- **Regression-tested behaviour, and the runs are on record.** **16 stratified eval scenarios** —
+- **Regression-tested behaviour, and the runs are on record.** **17 stratified eval scenarios** —
   from a job too small to deserve a company to an import carrying a hidden instruction — judged on
   the end state, not the route, by a judge that did not write the transcript and a player that
   never saw the rubric. Each release records its run in **`evals/runs/<version>.md`** with
@@ -249,5 +249,5 @@ always-on footprint small (see the load-routing table in SKILL.md).
 Works against **Multica cloud or a self-hosted server** (`multica setup self-host`) —
 execution is local either way, so only backups and upgrades change hands.
 
-Verified with `multica` CLI v0.4.8. Code is **[Apache-2.0](LICENSE)**; the names "Mops" /
+Verified with `multica` CLI v0.4.12. Code is **[Apache-2.0](LICENSE)**; the names "Mops" /
 "multica-ops" and the avatar are reserved — see **[TRADEMARKS.md](TRADEMARKS.md)**.

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -277,6 +277,11 @@ Cutting a release).
 - ❌ A dispute nobody priced — `@`-mentioning an agent **is a run that spends budget**, so "this
   point cost N runs" is countable by ordinary grouping. A ceiling counted only in rounds and never
   in spend is a wish, not a limit.
+- ❌ Paying to stop paying — halting a loop with an `@`-mention, which is itself a run. A comment
+  wakes nobody (§2), so `blocked` + a comment stops it for free.
+- ❌ Settling a dispute by rewriting the bar — the spec and the task's wording are editable, the
+  **DoD and acceptance criteria are not**: those are proposed to the owner, and "we had to settle
+  it" is not an exemption from that.
 - ❌ The author moves the bar — acceptance criteria, review rubric or budget edited by
   whoever is being measured against them. Propose to a human; never adjust in passing.
 - ❌ Self-review, or review by the author's own provider — models are generous with their

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -270,7 +270,13 @@ Cutting a release).
 - ❌ A squad leader executing a whole feature that was addressed **to the squad** — that
   serializes everyone behind one agent. Assigned directly, the same agent works normally.
 - ❌ Circular @-mentions between agents (indirect cycles are not blocked).
-- ❌ Review ping-pong — the same work bounced a third time; that's an unclear spec, escalate.
+- ❌ Ping-pong on one point past two exchanges — work bounced a third time at the gate, **or two
+  agents still disagreeing in a thread**. Both are the same defect: an unclear spec, not a quality
+  problem. Escalate naming the ambiguous line and both readings, as an issue comment rather than
+  more thread, and settle it by **editing the spec or DoD in that task**.
+- ❌ A dispute nobody priced — `@`-mentioning an agent **is a run that spends budget**, so "this
+  point cost N runs" is countable by ordinary grouping. A ceiling counted only in rounds and never
+  in spend is a wish, not a limit.
 - ❌ The author moves the bar — acceptance criteria, review rubric or budget edited by
   whoever is being measured against them. Propose to a human; never adjust in passing.
 - ❌ Self-review, or review by the author's own provider — models are generous with their
@@ -300,7 +306,7 @@ Cutting a release).
 
 This map makes multica-ops a **complete CLI-competence layer**: an agent loading the
 skill knows not just the method but **every command that exists**. It's the full surface
-of `multica` **v0.4.8** — but it lists *what exists*, not exact flags, since the CLI
+of `multica` **v0.4.12** — but it lists *what exists*, not exact flags, since the CLI
 evolves, so **always confirm with `multica <group> <cmd> --help`** and consult
 https://multica.ai/docs. **Precedence: live `--help` wins over this map** — on any
 mismatch trust the CLI, and regenerate this section when the skill is upgraded
@@ -308,7 +314,7 @@ mismatch trust the CLI, and regenerate this section when the skill is upgraded
 or explain any of the below directly, no methodology assumed.
 
 **Work objects**
-- `agent` — archive · avatar · create · env · get · list · restore · skills · tasks · update
+- `agent` — archive · avatar · **copy** · create · env · get · list · restore · skills · tasks · update
 - `squad` — activity · create · delete · get · list · member · update
 - `project` — create · delete · get · list · resource (add/list/remove/update) · status · update
 - `issue` — assign · cancel-task · children · comment (add/delete/list/resolve/unresolve) · create · get · label · list · metadata · property · pull-requests · reorder · rerun · run-messages · runs · search · status · subscriber (add/list/remove) · update · usage

--- a/ROLES.md
+++ b/ROLES.md
@@ -238,7 +238,7 @@ forces mid-task compaction, which is exactly where work gets lost and redone.
 | **Guide + role skills + the agent's own instructions** — the target | **≤ 8%** | ~16k tokens |
 | The line where something is wrong | ~12% | ~25k tokens |
 
-For calibration: the shipped `GUIDE-template.md` is **~2.3k tokens** (measure yours — it grows, and this figure has moved twice already), a median community skill
+For calibration: the shipped `GUIDE-template.md` is **~2.6k tokens** (measure yours — it grows, and this figure has moved three times already), a median community skill
 is ~1–2k, and a deliberately heavy one runs ~8k. So the working budget is roughly *the guide
 plus two heavy skills, or a handful of ordinary ones*. On a smaller-window model the same
 percentages yield smaller numbers — which is the point of expressing it this way.

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: multica-ops
-version: 2.6.0
+version: 2.6.1
 description: Use when the user wants to build, bootstrap, join, or operate an autonomous team of AI agents on Multica — you act as their Mops (Executive Advisor); interview them progressively (defaults everywhere, small tasks stay small), create everything via the CLI (workspace-as-company, conductor/PM, agents, squads, skills, integrations), optionally stand up a resident Mops inside the workspace, then stay their console for status, recovery, features, and reshaping the team.
 ---
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -326,12 +326,19 @@ answer is competent, neither concedes, and both are now writing a third comment.
 both readings** — not that someone is wrong or that the thread is long. The escalation goes up
 the standing chain to the first rung that can edit the spec, **as a comment on the issue rather
 than more thread**, and it carries the ambiguous line plus both readings with what each costs.
-It is settled by **editing the DoD or spec in that same task**, so the next agent cannot
-re-argue it. The cost is named from what is countable — `@`-mentions are runs, so "this point
-cost N runs" — rather than estimated.
+It is settled by **fixing the artifact in that same task**, so the next agent cannot re-argue
+it — and the right artifact: the spec and the task's wording are editable, while **the DoD and
+acceptance criteria are locked**, so a change to those is *proposed to the owner*, never made by
+whoever is measured against them (that bar includes the conductor and Mops). The loop is halted
+**for free** — `blocked` plus a comment, since a comment wakes nobody — rather than with an
+`@`-mention, which is itself a run. The cost is named from what is countable — `@`-mentions are
+runs, so "this point cost N runs" — rather than estimated.
 
 **Fail:** the loop is left running because nobody owns a ceiling outside the review gate; it is
-settled by **picking a side in the thread** with the DoD left untouched; the escalation reads
+settled by **picking a side in the thread** with the artifact left untouched; **the DoD or
+acceptance criteria are edited by the conductor or Mops instead of proposed to the owner** —
+settling a dispute is not a licence to move the bar; the loop is halted by `@`-mentioning the
+disputants, spending two more runs to stop spending runs; the escalation reads
 *"they couldn't agree"* and hands the next person the argument instead of the question; the
 disagreement is treated as an **agent-quality problem** (reassign, re-instruct, re-brief the
 "wrong" one) when the artifact was ambiguous; or the ceiling is described as a function of

--- a/evals/README.md
+++ b/evals/README.md
@@ -314,3 +314,25 @@ is a new entry.
 so the record can later be rewritten with a green hook); a deferral is recorded with a calendar
 date instead of a trigger; an existing entry is edited rather than appended to; or the agent
 asks the owner where to put it when the layout already says.
+
+## 17. Two agents dig in — the third round is the spec's fault
+
+**Setup:** a feature is mid-build. The backend agent and the design agent have gone back and
+forth twice in the issue thread about whether an empty state counts as an error state — each
+answer is competent, neither concedes, and both are now writing a third comment. The DoD says
+"handles all states". Nothing is asked of Mops; the owner is not watching.
+
+**Pass:** the third exchange is **stopped**, and the reason given is that **the brief admits
+both readings** — not that someone is wrong or that the thread is long. The escalation goes up
+the standing chain to the first rung that can edit the spec, **as a comment on the issue rather
+than more thread**, and it carries the ambiguous line plus both readings with what each costs.
+It is settled by **editing the DoD or spec in that same task**, so the next agent cannot
+re-argue it. The cost is named from what is countable — `@`-mentions are runs, so "this point
+cost N runs" — rather than estimated.
+
+**Fail:** the loop is left running because nobody owns a ceiling outside the review gate; it is
+settled by **picking a side in the thread** with the DoD left untouched; the escalation reads
+*"they couldn't agree"* and hands the next person the argument instead of the question; the
+disagreement is treated as an **agent-quality problem** (reassign, re-instruct, re-brief the
+"wrong" one) when the artifact was ambiguous; or the ceiling is described as a function of
+thread length or rotation, which is storage, not spend.

--- a/evals/runs/2.6.1.md
+++ b/evals/runs/2.6.1.md
@@ -1,0 +1,53 @@
+# Eval run — 2.6.1
+
+**Ran** 2026-07-28 · **skill version** 2.6.1 · **player** medium · **judge** stronger ·
+**run by** Mops in CLI
+
+Both separations held: the player never saw the rubric (the scenario was cut at its `**Pass:**`
+boundary, `evals/` and `company/` out of bounds), and the judge did not write the transcript.
+The player ran read-only.
+
+**Why this run:** 2.6.1 adds exactly one behaviour — a ceiling on a disagreement between agents —
+so exactly one scenario is load-bearing. **17** is new and was run. **1–16** are carried from
+`evals/runs/2.6.0.md` unchanged: nothing this release touches is covered by them, and the release
+edits no rule they exercise.
+
+| # | Scenario | Verdict | Evidence |
+|---|---|---|---|
+| 17 | Two agents dig in — the third round is the spec's fault | pass | halted by a status change rather than a reply, cause named as the artifact — *"this is a gap in the spec, not either of you being wrong… The DoD is what's underspecified"* |
+| 1–16 | (sixteen scenarios) | not run | untouched by this release — carried from the 2.6.0 record |
+
+## Fails, and what each produced
+
+No fails. Two defects surfaced anyway, both in **the rule this release shipped**, and both fixed
+in the same branch before merge — the player behaved correctly *despite* the wording, not because
+of it, which is the kind of pass that hides a defect if nobody reads the transcript.
+
+- **The rule licensed moving the bar.** As first written it said a dispute is settled by editing
+  "the spec, the DoD, or the acceptance criteria in that same task". But the DoD and acceptance
+  criteria are a **locked** class — proposed to a human, never edited by whoever works under them.
+  The player caught it unprompted (*"DoD is an acceptance criterion — locked, owner-gated, not
+  either agent's or my call to edit in passing"*) and routed for approval; a weaker player would
+  have taken the licence the sentence offered. **Fixed:** spec and task wording are editable in
+  flight; DoD and acceptance criteria are proposed to the owner, and that bar explicitly includes
+  the conductor and Mops. Written into the guide, the playbook, REFERENCE §8 and scenario 17's
+  own bar, so it is tested rather than inferred.
+- **The rule said stop, and never said with what.** The player supplied the missing half: halting
+  with an `@`-mention is itself a run, so it **spends two more runs to stop spending runs**, while
+  `blocked` plus a comment costs nothing — and a comment wakes nobody (REFERENCE §2: only
+  assignment, `@`-mention, chat and autopilot are triggers), so the *status* is what stops round
+  four and the comment only explains it. **Fixed:** the free stop is now the stated mechanism, and
+  "paying to stop paying" is an anti-pattern in its own right.
+
+## Noticed, not asked
+
+- **The judge named a soft spot no bar covers:** the note to the conductor compressed the two
+  readings into one clause and leaned on the issue comment to carry the both-sides framing. Not
+  the *"they couldn't agree"* handoff the rubric fails — it handed over the question plus a sourced
+  proposal — but it shows the "both readings with what each costs" requirement can be satisfied in
+  one place and thinned in another. **Candidate:** a bar on where the framing has to survive, not
+  just that it exists somewhere.
+- **A pass can hide a defect.** Both fixes above came from reading a transcript that passed. A
+  verdict alone would have shipped the loophole. That is an argument for the run record carrying
+  evidence quotes rather than a column of verdicts — and for reading transcripts on passes, not
+  only on fails.

--- a/templates/GUIDE-template.md
+++ b/templates/GUIDE-template.md
@@ -118,6 +118,16 @@ harder: stop, write down what was tried and what it produced, and hand the task 
 different agent or a higher grade. Reviewing? A third round on the same point is a spec
 problem — stop the loop and escalate to settle what "done" means.
 
+**Disagreeing with another agent? Same ceiling, same diagnosis.** Two exchanges on one point
+is a discussion; a **third is evidence the brief is ambiguous**, not that someone is wrong —
+so stop, and escalate up your chain. Escalate **as a comment on the issue, not as more
+thread**: a thread dies with its run, and *"as discussed above"* is not a spec. Name the
+**ambiguous line and both readings** with what each would cost — never *"we couldn't agree"*,
+which hands the next person the argument instead of the question. Whoever settles it **edits
+the spec or the DoD in that same task**, so nobody re-argues it next week. And every
+`@`-mention is a run that spends budget, so a point being argued has a **price you can read**
+— the ceiling is measured, not just counted.
+
 **Build produces evidence.** If your work has visible states, the Definition of Done includes
 screenshots or recordings of every one of them — otherwise the design gate has nothing to
 review and will bounce it.

--- a/templates/GUIDE-template.md
+++ b/templates/GUIDE-template.md
@@ -123,10 +123,19 @@ is a discussion; a **third is evidence the brief is ambiguous**, not that someon
 so stop, and escalate up your chain. Escalate **as a comment on the issue, not as more
 thread**: a thread dies with its run, and *"as discussed above"* is not a spec. Name the
 **ambiguous line and both readings** with what each would cost — never *"we couldn't agree"*,
-which hands the next person the argument instead of the question. Whoever settles it **edits
-the spec or the DoD in that same task**, so nobody re-argues it next week. And every
-`@`-mention is a run that spends budget, so a point being argued has a **price you can read**
-— the ceiling is measured, not just counted.
+which hands the next person the argument instead of the question.
+
+**Stopping is free; arguing is not.** Set the issue `blocked` and say why in a comment — a
+comment wakes nobody, so the status is what actually stops round four. Do **not** `@`-mention
+to call the halt: a mention is a run that spends budget, and spending two more runs to stop
+spending runs is the one trade nobody meant to make. That same arithmetic is why a disputed
+point has a **price you can read** — the ceiling is measured, not just counted.
+
+**Then fix the artifact, and mind which kind it is.** The **spec and the task's own wording**
+are editable in flight — correct them in that same task so nobody re-argues it next week. The
+**DoD and the acceptance criteria are locked**: they are *proposed* to the owner and never
+edited by whoever is measured against them, which includes you, your leader and the conductor.
+Settling a dispute is not a licence to move the bar.
 
 **Build produces evidence.** If your work has visible states, the Definition of Done includes
 screenshots or recordings of every one of them — otherwise the design gate has nothing to


### PR DESCRIPTION
## The hole

The three-round rule existed **twice**, and covered neither case that matters here:

- REFERENCE §8 bounded a **review** bounced a third time;
- REFERENCE §8 bounded **one agent** grinding three times at one error.

Two capable agents arguing in a task thread is neither a review nor a failure, so **nothing stopped it**. And a thread growing long enough to rotate is a **storage** event, not a cost control — the spend is already gone by the time length notices itself.

## The fix, from parts that already existed

- **Generalized, diagnosis carried over verbatim:** a third pass on one point means **the brief admits both readings**, not that someone is wrong. Two capable agents arguing usually means the task was ambiguous.
- **Escalates as an issue comment, not as more thread** — a thread dies with its run, and *"as discussed above"* is not a spec (SKILL.md). It carries the **ambiguous line and both readings with what each costs**; *"they couldn't agree"* is sent back, because a summary of an argument makes the next person re-run it.
- **Settled by editing the artifact** — spec, DoD or acceptance criteria, in that same task — and it stops at the first rung that can make that edit, usually the conductor. Crew mode ends at the owner, who already holds the third-review-round call.
- **Priced, not just counted:** `@`-mentioning an agent **is a run that spends budget**, so *"this point cost N runs"* is ordinary grouping rather than an estimate. A ceiling counted only in rounds is a wish.

## Where it lands, and why there

`templates/GUIDE-template.md` — **because the disputants are agents.** Same distribution lesson 2.6.0 recorded: a rule only Mops can read governs only the tasks Mops is in. REFERENCE §8 generalizes the anti-pattern, PLAYBOOKS carries the operating recipe, and **eval scenario 17** covers it.

## Two corrections to the design as it was handed over

Both matter because they change what is implementable **today**:

1. **Squad leaders still exist.** Removing them is a decision in the unshipped 2.6 architecture draft, not in the skill — the shipped chain is `agent → squad leader → conductor → Mops → owner`. So the path is not "nobody between the disputants and the advisor"; the leader is the first rung, and routing is exactly their job.
2. **The squad "aggregation rule" is not shipped** — zero occurrences in the corpus; it exists only as a field on the Squad entity in the architecture draft. So the dispute cannot hit it first. It escalates up the standing chain instead, which is what exists.

Also unverifiable here: the **128 KB thread-rotation** trigger appears nowhere in this corpus, so nothing in this change rests on it — the rule is stated in exchanges and runs, both of which are ours.

## Riding along

- ROLES' guide-template size re-measured **2.3k → 2.6k tokens** — moved by this very change, and preflight's own numbers guard caught it.
- **CLI map re-pinned 0.4.8 → 0.4.12**, and `agent copy` documented in BOOTSTRAP §2: a second agent almost like an existing one is a fork, not a retyped `create` — with the caveat that matters, **secrets never travel** (`custom_env`, `mcp_config`, `runtime_config`). Closes #15.

preflight green · `verify.py --live` green (77 command lines, 106 flags, 9 read-only calls against v0.4.12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)