### PR TITLE
Reachability, checked in both directions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,7 +152,7 @@ A version bump is not just a changelog entry. Before you tag:
    that no longer matches reality passes silently, which is worse than no guard.
 4. **Every new capability has a door, or a stated reason it doesn't** — see *When a flow
    deserves a command*. Reachability is guarded; the decision to add a command is not.
-5. **`bash scripts/preflight.sh`, `python3 scripts/verify.py --live`, and `python3 scripts/fetch-source.py --verify` green** (warnings named) — the last walks `sources/SOURCES.md` so the register's live URLs are re-checked each release alongside the skill's own sources.
+5. **`bash scripts/preflight.sh`, `python3 scripts/verify.py --live`, and `python3 scripts/fetch-source.py --verify` then `--verify-citations` green** (warnings named) — the last two walk `sources/SOURCES.md` in both directions: the register's live URLs are re-checked, and every `cited-by` is re-checked against the line it points at, since a rewrite moves the claim without touching the register.
 6. **Changelog** leads with the capability or the consequence, not the archaeology of how a
    defect was found (that goes in the commit message).
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -115,7 +115,7 @@ memory.
 | **[PLAYBOOKS.md](PLAYBOOKS.md)** | running a standard operation — "how do I…", `/mops health` `/mops upgrade` `/mops switch` `/mops import`, onboarding, the cost ledger |
 | **[REFERENCE.md](REFERENCE.md)** | object model, anti-patterns, **full CLI surface (§10)**, **frameworks per stage (§11)** |
 | **[WORKFLOW.md](WORKFLOW.md)** | explaining the process visually — bootstrap, two seats, conveyor, escalation, limits, the skill lifecycle |
-| [templates/](templates/) · [scripts/](scripts/) | writing a guide, roadmap, brand, component doc, decisions log, architecture map, tooling register or team roster · ops helpers (board listing, resume, health, backlog import) |
+| [templates/](templates/) · [scripts/](scripts/) · [sources/](sources/SOURCES.md) | writing a guide, roadmap, brand, component doc, decisions log, architecture map, tooling register or team roster · ops helpers (board listing, resume, health, backlog import) · **what we already hold on a topic**, and answering *"с чего ты взял"* |
 
 ## One front door — three questions, then the right path
 

--- a/scripts/check-structure.py
+++ b/scripts/check-structure.py
@@ -138,18 +138,68 @@ try:
 except OSError:
     pass
 
-# g · every docs file the stand-up creates needs a template, or an explicit exemption.
-EXEMPT = {"LATER", "ECONOMICS", "analytics"}
+# g · every template the stand-up skeleton declares must exist. Read from the table's own
+# Template column, not from the prose around it: the previous regex stopped at the first blank
+# line and so saw one path out of nineteen, passing green on almost nothing checked. Hence the
+# empty-table guard below — a check that silently reads nothing is worse than no check.
+DECLARED = set()
 try:
     boot = open("BOOTSTRAP.md", encoding="utf-8").read()
-    step = re.search(r"^7\. \*\*Labels\*\*.*?(?=\n\n|\n## )", boot, re.S | re.M)
-    if step:
-        for name in set(re.findall(r"`docs/([A-Z][A-Za-z]*)\.md`", step.group(0))):
-            if name in EXEMPT:
-                continue
-            if not os.path.exists(f"templates/{name}-template.md"):
-                warn(f"docs/{name}.md is in the stand-up skeleton with no templates/{name}-template.md")
+    rows = re.findall(r"^\s*\|\s*`(docs/[^`]+)`\s*\|[^|]*\|[^|]*\|\s*([^|]*?)\s*\|", boot, re.M)
+    if not rows:
+        fail("BOOTSTRAP: the repo-layout table has no `docs/…` rows — the template guard is blind")
+    for path, tmpl in rows:
+        name = tmpl.split()[0] if tmpl.strip() else ""
+        if not name or name.startswith("—"):
+            continue  # the row declares no template, deliberately
+        DECLARED.add(name)
+        if not os.path.exists(f"templates/{name}-template.md"):
+            fail(f"BOOTSTRAP: {path} declares template '{name}' — templates/{name}-template.md is missing")
 except OSError:
+    pass
+
+# i · a file nothing points at is a file nobody opens. Links were checked forwards only, so a
+# store could sit in the repo with every link inside it valid and no door into it — worse than
+# a dangling link, because the chain reads as intact from both ends while nothing traverses it.
+# Reachable = named (by path or filename) in some other tracked file, or declared in the
+# skeleton table above. The exemptions are the paths something *outside* this repo reaches by
+# convention; each says who reaches it, so an obsolete exemption is legible rather than silent.
+CONVENTION = {
+    "commands/": "the plugin loads the directory; check f2 owns the COMMANDS.md row",
+    "evals/runs/": "release records, reached by version in preflight 5j",
+    ".github/workflows/": "run by GitHub, by path",
+    ".claude-plugin/": "read by the plugin loader, by name",
+    "scripts/tests/": "collected by the test runner",
+    "assets/": "used by the docs site, the social preview and the plugin listing — none in this repo",
+    ".gitignore": "read by git",
+}
+try:
+    tracked = subprocess.run(["git", "ls-files"], capture_output=True, text=True, check=True)
+    paths = [p for p in tracked.stdout.split("\n") if p]
+    # CHANGELOG is history, not a pointer: a file whose only mention is its own release note is
+    # orphaned in the live documentation, which is exactly the state we are looking for.
+    corpus = {}
+    for p in paths:
+        if p == "CHANGELOG.md" or p.endswith((".png", ".jpg", ".ico")):
+            continue
+        try:
+            corpus[p] = open(p, encoding="utf-8", errors="ignore").read()
+        except OSError:
+            pass
+    for p in paths:
+        if any(p == k or p.startswith(k) for k in CONVENTION):
+            continue
+        base = os.path.basename(p)
+        if base.endswith("-template.md") and base[:-len("-template.md")] in DECLARED:
+            continue  # declared in the skeleton table, which check g holds to its word
+        # Match on a name boundary, or a guard reports reachability it never established:
+        # `SKILL-SCAFFOLD.md` ends with the name `OLD.md`. A leading path segment is fine —
+        # `${CLAUDE_PLUGIN_ROOT}/templates/mops-alias.md` is a reference like any other.
+        named = re.compile(r"(?<![\w-])(?:%s|%s)" % (re.escape(p), re.escape(base)))
+        if not any(named.search(t) for q, t in corpus.items() if q != p):
+            warn(f"{p} is reachable from nothing — no other file names it, and it is not "
+                 f"one of the convention-reached paths")
+except (OSError, subprocess.CalledProcessError):
     pass
 
 # h · every `multica <group> <sub>` the docs promise must exist in the installed CLI.

--- a/scripts/fetch-source.py
+++ b/scripts/fetch-source.py
@@ -11,6 +11,7 @@ get this".
     python3 scripts/fetch-source.py --resolve https://example.org/paper  # landing-page title
     python3 scripts/fetch-source.py --archive https://arxiv.org/abs/2411.10109
     python3 scripts/fetch-source.py --verify                             # walk the register
+    python3 scripts/fetch-source.py --verify-citations                   # walk it backwards
 
 `--resolve` fetches metadata (arXiv API for arXiv ids, Crossref for DOIs, the page <title>
 otherwise) and prints a ready SOURCES.md block skeleton stamped with today's check-date —
@@ -19,6 +20,10 @@ best-effort triggers a Wayback Save Page Now and prints the availability-API sna
 a failure degrades to a warning, never an error. `--verify` GETs every live URL in the
 register with a browser-ish UA and reports what no longer resolves, with the remediation
 ladder: transient? → bot-block? → hunt the successor.
+
+`--verify-citations` walks the same register in the other direction — each entry's
+`Cited-by: file:line` back into the docs. Both edges matter: `--verify` proves the evidence
+still exists, this proves the skill still uses it. Offline, so it is the cheap one to run.
 
 Stdlib only — no network library beyond urllib, so it runs anywhere Python does.
 """
@@ -217,12 +222,110 @@ def verify():
     return 1 if dead else 0
 
 
+_STOP = {"language", "models", "research", "skill", "skills", "should", "because", "between",
+         "carries", "different", "against", "instead", "without", "already", "little"}
+
+
+def _anchors(e):
+    """What proves a pointer still lands on its claim, in two forms — because prose cites a
+    source two ways. **By name**: the surname, product or handle a sentence says out loud
+    ("Park et al.", "FrugalGPT", "agentman"). **By substance**: the figures and terms the
+    distillate carries, for the many claims that use a study's numbers without naming it.
+    Either one near the pointer is proof enough; the first is also what we hunt for elsewhere
+    in the file, since a name that lives 40 lines away is what drift looks like."""
+    src = e["heading"] + " " + e["citation"]
+    named = set(re.findall(r"\b([A-Z][A-Za-z]{3,})\b(?=\s*[,.\"]|\s+et\s+al)", src))
+    named |= set(re.findall(r"`([\w-]{4,})`", src))
+    named |= {w for w in re.split(r"[-_]", e["id"]) if len(w) >= 5}
+    named |= set(re.findall(r"(?:^|\s)([a-z][a-z0-9]{4,})\s+—", e["citation"]))
+    substance = {w for w in re.findall(r"[A-Za-z][A-Za-z-]{5,}", e["distillate"])}
+    substance |= set(re.findall(r"\d{2,}", e["distillate"]))
+    return ({w.lower() for w in named} - _STOP,
+            {w.lower() for w in substance} - _STOP)
+
+
+def verify_citations():
+    """The register's other edge. Every entry names the `file:line` that cites it, and nothing
+    ever checked that the line still does — a doc gains three paragraphs and the pointer
+    quietly names an unrelated sentence. That is worse than a dead link: the claim still reads
+    as sourced, and the source still reads as used, while the two no longer meet.
+
+    Structure is proved (the file, the line, that it is not blank). Drift is only *claimed*
+    where it can be shown: the pointer names neither the source nor its substance, while the
+    source's name demonstrably lives elsewhere in that same file — then the nearest real
+    occurrence is printed and the fix is a one-number edit. An entry whose name appears nowhere
+    in the file cannot be judged either way and is left alone rather than guessed at; a guard
+    that cries wolf is read once and then skipped, which is worse than not having it.
+    """
+    try:
+        text = open("sources/SOURCES.md", encoding="utf-8").read()
+    except OSError:
+        print("! sources/SOURCES.md not found — run from the repo root", file=sys.stderr)
+        return 1
+
+    entries, cur = [], None
+    for line in text.split("\n"):
+        m = re.match(r"^### (\S+) · (.*)$", line)
+        if m:
+            cur = {"id": m.group(1), "heading": m.group(2), "citation": "",
+                   "distillate": "", "cited": ""}
+            entries.append(cur)
+        elif cur and (m := re.match(r"^- \*\*(Citation|Distillate|Cited-by):\*\* (.*)$", line)):
+            cur[m.group(1).lower().replace("cited-by", "cited")] = m.group(2)
+
+    files, bad, drift, uncited, checked = {}, 0, 0, [], 0
+    for e in entries:
+        pointers = re.findall(r"([\w./-]+\.md):(\d+)", e["cited"])
+        if not pointers:
+            uncited.append(f"{e['id']} — Cited-by: {e['cited'] or '(empty)'}")
+            continue
+        named, substance = _anchors(e)
+        for path, num in pointers:
+            checked += 1
+            if path not in files:
+                try:
+                    files[path] = open(path, encoding="utf-8").read().split("\n")
+                except OSError:
+                    files[path] = None
+            lines = files[path]
+            if lines is None:
+                print(f"  ✗ {e['id']} → {path}:{num} — no such file"); bad += 1; continue
+            n = int(num)
+            if not 1 <= n <= len(lines):
+                print(f"  ✗ {e['id']} → {path}:{num} — file has {len(lines)} lines"); bad += 1; continue
+            if not lines[n - 1].strip():
+                print(f"  ✗ {e['id']} → {path}:{num} — points at a blank line"); bad += 1; continue
+            low = [l.lower() for l in lines]
+            window = " ".join(low[max(0, n - 4):n + 3])
+            # A substance word only counts where it is *distinctive*: "persona" is on every
+            # third line of MODULES and proves nothing, "83" and "cookiy" are on two.
+            rare = {a for a in substance if 0 < sum(a in l for l in low) <= 3}
+            if any(a in window for a in named | rare):
+                continue
+            hits = [i + 1 for i, l in enumerate(low) if any(a in l for a in named)]
+            if hits:
+                near = min(hits, key=lambda h: abs(h - n))
+                print(f"  ! {e['id']} → {path}:{num} — “{lines[n - 1].strip()[:52]}…”"
+                      f" carries neither the name nor the finding; nearest is {path}:{near}")
+                drift += 1
+
+    for u in uncited:
+        print(f"  ! uncited: {u}")
+    print(f"  citations: {checked - bad - drift}/{checked} back-pointers land on their claim"
+          + (f", {len(uncited)} entr{'y' if len(uncited) == 1 else 'ies'} cited by nothing" if uncited else ""))
+    if drift:
+        print("  remediation: move the line number to the nearest match above, or re-cite the claim")
+    return 1 if bad else 0
+
+
 if __name__ == "__main__":
     ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
     g = ap.add_mutually_exclusive_group(required=True)
     g.add_argument("--resolve", metavar="ID", help="doi | arxiv-id | url → SOURCES.md skeleton")
     g.add_argument("--archive", metavar="URL", help="Wayback Save Page Now + availability link")
     g.add_argument("--verify", action="store_true", help="check every live URL in the register")
+    g.add_argument("--verify-citations", action="store_true",
+                   help="check every Cited-by back-pointer still lands on its claim")
     a = ap.parse_args()
 
     if a.resolve:
@@ -231,3 +334,5 @@ if __name__ == "__main__":
         sys.exit(archive(a.archive))
     if a.verify:
         sys.exit(verify())
+    if a.verify_citations:
+        sys.exit(verify_citations())

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -57,10 +57,21 @@ for f in $(ls *.md | grep -vE '^(README|CHANGELOG)\.md$'); do
   grep -q "$f" README.md || say_fail "README.md does not mention $f"
 done
 
-# 4 · internal .md links resolve
-for l in $(grep -rohE '\]\([A-Za-z0-9_.-]+\.md\)' ./*.md templates/*.md 2>/dev/null | sed 's/](//;s/)//' | sort -u); do
-  [ -f "$l" ] || say_fail "broken link: $l"
-done
+# 4 · internal .md links resolve — from every doc we ship, not only the root ones, and
+# including links that carry a path (`](templates/X.md)`): the filename-only pattern skipped
+# those silently, so a whole class of link could rot inside the check's own blind spot.
+link_bad=$(python3 - <<'PYEOF'
+import glob, os, re
+bad = []
+for f in (glob.glob("*.md") + glob.glob("templates/*.md") + glob.glob("commands/*.md")
+          + glob.glob("evals/*.md") + glob.glob("evals/runs/*.md") + glob.glob("sources/*.md")):
+    for l in re.findall(r"\]\(([A-Za-z0-9_./-]+\.md)(?:#[^)]*)?\)", open(f, encoding="utf-8").read()):
+        if not (os.path.exists(l) or os.path.exists(os.path.join(os.path.dirname(f), l))):
+            bad.append(f"broken link in {f}: {l}")
+print("\n".join(sorted(set(bad))))
+PYEOF
+)
+[ -n "$link_bad" ] && while IFS= read -r l; do say_fail "$l"; done <<< "$link_bad"
 
 # 5a · official guidance: SKILL.md body under 500 lines
 lines=$(wc -l < SKILL.md | tr -d ' ')
@@ -145,6 +156,7 @@ PYEOF
 for f in scripts/*; do
   b=$(basename "$f")
   [ "$b" = "preflight.sh" ] && continue
+  git check-ignore -q "$f" && continue   # build artifacts (__pycache__) are not documentation
   grep -rql -- "$b" ./*.md 2>/dev/null || say_warn "scripts/$b is not mentioned in any doc"
 done
 
@@ -163,7 +175,7 @@ PYEOF
 )
 [ -n "$gt_bad" ] && say_warn "$gt_bad"
 
-# 5i · structural integrity — eight classes of defect that each shipped once.
+# 5i · structural integrity — nine classes of defect that each shipped once.
 # Deterministic ones fail, heuristic ones warn. See scripts/check-structure.py.
 if [ -f scripts/check-structure.py ]; then
   while IFS= read -r line; do

--- a/sources/SOURCES.md
+++ b/sources/SOURCES.md
@@ -20,7 +20,10 @@ copyrightable. Each entry states its tier.
 
 **Upkeep.** `scripts/fetch-source.py` builds and checks these entries: `--resolve <doi|arxiv|url>`
 prints a skeleton, `--archive <url>` triggers a Wayback snapshot, `--verify` walks every live URL.
-`--verify` runs each release (AGENTS.md → Cutting a release).
+`--verify-citations` walks the **other** edge — every cited-by back into the doc that cites it —
+naming any pointer a rewrite left behind, and any entry the skill no longer cites at all (one
+parked for a later release stays named every run, which is the point: a deferral nobody is
+reminded of is a deletion). Both run each release (AGENTS.md → Cutting a release).
 
 ---
 
@@ -70,7 +73,7 @@ prints a skeleton, `--archive <url>` triggers a Wayback snapshot, `--verify` wal
 - **Licence:** copyrighted (MeasuringU) — cite + archive + our distillate
 - **Distillate:** Reviews ~12 recent experiments with synthetic users and finds mixed results, with synthetic responses showing **artificially low variability** and **distorted magnitudes** relative to real respondents — so they can indicate direction but not the size of an effect. (Their framing — low variability and distortion — is what the skill states, *not* "clustering toward neutral.")
 - **Check-date:** 2026-07-27
-- **Cited-by:** MODULES.md:168, MODULES.md:335
+- **Cited-by:** MODULES.md:168, MODULES.md:340
 
 <!-- Mahajan restore point: MODULES.md previously credited a "Mahajan synthetic-users taxonomy"
      cited by name only. Research (2026-07-27) could not locate any such work in the checked
@@ -164,7 +167,7 @@ prints a skeleton, `--archive <url>` triggers a Wayback snapshot, `--verify` wal
 - **Licence:** free — cookiy's `user-research-skill` is **MIT** (a copy may be carried later; today only the method shape is adapted, nothing embedded). agentman: **no licence stated on the page**; concepts taken, nothing embedded (no code carried, so no licence obligation).
 - **Distillate:** Method lineage, not evidence. cookiy's MIT skill supplied the **shape** of the qualitative-research flows (its `qualitative-research-planner` → our persona-interview flow, its `synthesize-research-report` → our QDA step), adapted through the import gate. agentman supplied the **calibration and cohort concepts** behind the persona response-calibration layer. Recorded so every adaptation is auditable and no vendor wrapper is smuggled in.
 - **Check-date:** 2026-07-27
-- **Cited-by:** MODULES.md:187, MODULES.md:221, MODULES.md:304; ROLES.md:339
+- **Cited-by:** MODULES.md:187, MODULES.md:221, MODULES.md:309; ROLES.md:339
 
 ### standards-cluster · named review standards
 - **Citation:** Nielsen, J. "10 Usability Heuristics for User Interface Design" (NN/g). W3C, "Web Content Accessibility Guidelines (WCAG)." Wharton, Rieman, Lewis & Polson, "The Cognitive Walkthrough Method" (1994).

--- a/templates/GUIDE-template.md
+++ b/templates/GUIDE-template.md
@@ -41,7 +41,11 @@ budget cap and this guide's invariants are **proposed** to a human, never adjust
 you work under them.
 
 **Evidence over opinion:** research before inventing; cite sources; mark opinion as
-opinion. **Self-improvement:** a routine repeated twice → shape it into a skill
+opinion. **And look here before you research** — `docs/research/` already holds this project's
+discovery notes, usability sessions and persona runs, and `docs/DECISIONS.md` holds what was
+tried and rejected, with the evidence. Asked *what do we know about X* — start there, then go
+outside and say which is which. Re-running a study the team already paid for is the expensive
+way to look thorough. **Self-improvement:** a routine repeated twice → shape it into a skill
 (skill-creator) → ask **whoever holds the skill inventory** (the conductor, or the owner in crew mode) to attach
 it. **Self-serve skills:** find what you lack via find-skills → that person **screens, trims
 and attaches** it. Never attach a


### PR DESCRIPTION
A store with a writer and no reader is worse than a dangling link: both ends still read as
connected while nothing traverses the middle. Three guards were checking only the forward
edge, and one of them had stopped checking almost anything at all.

### The template guard was reading one row out of nineteen

`check-structure.py` matched `^7. **Labels**.*?(?=\n\n|\n## )` — non-greedy to the first blank
line, which ends four lines *above* the table it exists to read. It saw one path picked out of
the prose, `docs/ARCHITECTURE.md`; `ROADMAP`, `TEAM`, `TOOLING`, `DECISIONS` and `BUDGET` were
guarded by nothing while the check reported green. It now reads the table's own Template
column, and **fails when that table yields no rows at all** — a check that silently reads
nothing is worse than no check.

### New check `i` — orphans

Every tracked file must be named by another tracked file, or sit under a path something
outside this repo reaches by convention (each exemption states who reaches it). CHANGELOG
mentions don't count: a file whose only live mention is its own release note is already
orphaned. Matching is on a name boundary — `SKILL-SCAFFOLD.md` ends with the name `OLD.md`,
which the first cut of the check happily accepted as reachability.

Green today; it holds the invariant forward.

### The sources register now walks backwards too

`--verify` proved the evidence still exists; nothing proved the skill still uses it. **Two of
23 back-pointers had already drifted five lines each** — `ls-review` named a paragraph about
consent withdrawal, `method-provenance` one about paying participants. Both entries still read
as sourced, both claims still read as cited, and every guard was green.

`--verify-citations` proves structure, and claims drift only where it can show it: the pointer
carries neither the source's name nor its findings while the name demonstrably lives elsewhere
in that file — then it prints the nearest real occurrence, so the fix is a one-number edit. An
entry whose name appears nowhere is left alone; a guard that cries wolf gets read once and
skipped. Substance words count only where distinctive ("persona" is on every third line of
MODULES and proves nothing; "83" and "cookiy" are on two). It also names the three entries
nothing cites — parked for 2.7, and a deferral nobody is reminded of is a deletion.

### Two doors that were missing

- **`docs/research/`** is created by the stand-up, written by `/mops research`, fed by
  usability sessions and persona runs — and the guide every agent reads never named it once.
  Asked what we already know about X, an agent went outside and researched it again.
- **`sources/SOURCES.md`** answered *"с чего ты взял"* from prose in the always-loaded core but
  had no row in the load-routing table, so the enumerating form of the question — *what do we
  already hold on this?* — reached the register only by luck. Folded into the
  templates/scripts row at zero line cost; the core sits at 500/500 lines, ~8985/9000 tokens.

### Also

The internal-link check skipped every link carrying a path (no `/` in its character class) and
never looked outside the root and `templates/`; `5g` warned about `__pycache__`, which git
ignores.

### Not in this PR

No version bump and no changelog entry — guard work and two doc doors, which per AGENTS.md
*"batch, don't drip"* ride the next real release.

`preflight` · `verify.py` · `fetch-source.py --verify-citations` · the helper tests all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)